### PR TITLE
Add core MCP Trust Framework specifications

### DIFF
--- a/specs/MCPF-1.0.md
+++ b/specs/MCPF-1.0.md
@@ -1,0 +1,284 @@
+# MCP Trust Framework (MCPF) – Version 1.0 (Draft)
+
+**Status:** Public Draft  
+**Maintainer:** Veritrust  
+**Applies to:** Any MCP server and host implementation
+
+---
+
+## 1. Introduction
+
+The **Model Context Protocol (MCP)** enables AI agents and hosts to interact with external tools and data sources in a structured way. MCP defines *how* tools are described and invoked.
+
+However, MCP does **not** define:
+
+- How to **identify** MCP servers and agents
+- How to **discover** available MCP servers
+- How to **express trust, provenance, and assurance** about MCP servers
+- How to **apply policies** about which MCP servers a host is permitted to use
+
+The **MCP Trust Framework (MCPF)** fills this gap by specifying:
+
+- An **identity model** for MCP servers and agents based on Decentralized Identifiers (DIDs)
+- A **verifiable credential** model for expressing trust and provenance
+- A **registry model and API** for discovering MCP servers
+- A **verification flow** for hosts before invoking MCP servers
+- A **policy model** to decide whether a server is trusted enough to use
+
+MCPF is compatible with existing MCP implementations and is transport- and vendor-agnostic.
+
+---
+
+## 2. Scope
+
+MCPF:
+
+- DOES NOT modify the MCP protocol or wire format.
+- DOES define:
+  - How MCP servers and agents identify themselves.
+  - How registries can publish and expose trusted MCP servers.
+  - How hosts can verify identity and trust information before invocation.
+- Applies to:
+  - Public MCP servers on the internet
+  - Private/enterprise MCP deployments
+  - Hybrid setups across organizational boundaries
+
+---
+
+## 3. Terminology
+
+- **MCP Server**  \
+  A tool or service that implements the Model Context Protocol and exposes capabilities to hosts/agents.
+
+- **Host / Agent**  \
+  An AI agent, application, or host runtime that initiates MCP calls to MCP servers.
+
+- **Registry**  \
+  A service that maintains a directory of MCP servers, indexed by decentralized identifiers (DIDs) and associated metadata and credentials.
+
+- **DID (Decentralized Identifier)**  \
+  A persistent identifier that can be resolved to a DID Document describing public keys and service endpoints. See W3C DID Core.
+
+- **VC (Verifiable Credential)**  \
+  A tamper-evident credential expressing claims about a subject, signed by an issuer. See W3C Verifiable Credentials.
+
+- **Issuer**  \
+  An entity that signs verifiable credentials (e.g., a trust authority such as Veritrust).
+
+- **Trust Policy**  \
+  A set of local rules that determine which MCP servers are acceptable to a given host or organization, based on DIDs, issuers, capabilities, and assurance levels.
+
+- **Assurance Level**  \
+  A coarse-grained indicator of how thoroughly an MCP server has been evaluated, e.g. `basic`, `verified`, `certified`.
+
+---
+
+## 4. Identity Model
+
+Every MCP server that participates in MCPF SHOULD have a stable **DID** as its primary identifier.
+
+Example using `did:web`:
+
+```text
+did:web:veritrust.vc:mcp:edgeguard-siem
+```
+
+### 4.1. DID Document
+
+The DID MUST resolve to a DID Document that:
+
+- Contains at least one `verificationMethod` with a public key used to sign credentials or metadata.
+- Declares assertion methods (e.g., which keys can sign VCs).
+- May include service entries referencing:
+  - The MCP server endpoint
+  - A registry entry URL
+  - Documentation URLs
+
+See `did-profile.md` for concrete recommendations and examples.
+
+---
+
+## 5. MCPServerCredential
+
+MCPF defines a standard Verifiable Credential type called `MCPServerCredential`.
+
+This credential expresses information about an MCP Server, such as:
+
+- Its DID
+- The organization operating it
+- The primary MCP endpoint
+- A URL to its MCP manifest
+- Its capabilities
+- An assurance level
+- Validity period
+
+### 5.1. Required Fields
+
+An `MCPServerCredential` MUST include:
+
+- `@context` – MUST include the W3C VC context and the MCP-specific context.
+- `type` – MUST include `"VerifiableCredential"` and `"MCPServerCredential"`.
+- `issuer` – Identifier (e.g., DID) of the issuer.
+- `issuedAt` – Time the credential was issued (ISO 8601).
+- `validUntil` – Time the credential expires (ISO 8601).
+- `credentialSubject` – Object containing:
+  - `id` (DID of the MCP server)
+  - `operator` (string, organization name)
+  - `endpoint` (URI for the MCP endpoint)
+  - `manifest` (URI for MCP manifest JSON)
+  - `capabilities` (array of strings)
+  - `assuranceLevel` (one of: `basic`, `verified`, `certified`)
+
+The full JSON Schema is defined in `credential-schema.json`.
+
+---
+
+## 6. Registry Model
+
+A registry is a service that indexes MCP servers by DID, along with metadata and verifiable credentials.
+
+A registry entry SHOULD at minimum contain:
+
+- The server’s DID
+- An endpoint URL
+- A manifest URL
+- A list of credentials (or credential URLs)
+- Metadata describing capabilities and organizational context
+
+Example structure:
+
+```json
+{
+  "did": "did:web:example.com:mcp:myserver",
+  "endpoint": "https://myserver.example.com/mcp",
+  "manifest": "https://myserver.example.com/mcp/manifest.json",
+  "credentials": [
+    "https://registry.example.com/vc/myserver.json"
+  ],
+  "metadata": {
+    "capabilities": ["telemetry", "alerts"],
+    "organization": "Example Corp",
+    "country": "US",
+    "tags": ["security", "energy"],
+    "status": "active"
+  }
+}
+```
+
+The Registry API is described in detail in `registry-api.md`.
+
+Registries MAY be:
+
+- Publicly accessible (e.g., a global trust authority)
+- Restricted to an organization (private enterprise registry)
+- Federated (multiple registries with cross-references)
+
+---
+
+## 7. Verification Flow
+
+Before a host invokes an MCP server under MCPF, it SHOULD perform the following steps:
+
+1. **Resolve DID** – Obtain the DID Document for the MCP server’s DID.
+2. **Validate DID Document**
+   - Check structure and syntax.
+   - Extract verification methods and service endpoints.
+3. **Fetch Registry Entry** (optional but recommended) – Query a registry to retrieve metadata and credential references for the DID.
+4. **Obtain MCPServerCredential** – Either from the registry or directly from the MCP server.
+5. **Validate against the JSON Schema.**
+6. **Verify Credential**
+   - Check that the credential is issued by a trusted issuer.
+   - Validate digital signature (implementation-specific).
+   - Ensure `issuedAt` and `validUntil` are within acceptable range.
+7. **Check Revocation** – Consult registry or issuer revocation lists or status endpoints.
+8. **Apply Local Trust Policy** – Evaluate whether:
+   - Issuer is allowed.
+   - `assuranceLevel` meets minimum requirements.
+   - Capabilities are acceptable.
+   - Other metadata (country, tags, etc.) matches organizational policy.
+9. **Fetch and Validate Manifest** – Retrieve MCP manifest from the URL in credential or registry. Optionally check hash/integrity if available.
+10. **Establish TLS Connection** – Connect to the MCP endpoint using HTTPS. Validate TLS certificate as usual.
+
+Only after these steps does the host proceed to use the MCP server in the normal MCP call flow.
+
+---
+
+## 8. Trust Policies
+
+Each organization or host MAY define its own trust policy, for example:
+
+- Only accept MCP servers with:
+  - `assuranceLevel >= "verified"`
+  - `issuer` in an approved list of trust authorities
+  - capabilities restricted to a defined set
+  - `country` not in a blocked list
+- Reject or warn on:
+  - Expired credentials
+  - Revoked credentials
+  - Unknown issuers
+
+Trust policies are not standardized by MCPF; they are local configuration. MCPF only defines the information model to support such policies.
+
+---
+
+## 9. Registry Discovery
+
+Trust authorities and registries MAY expose a `.well-known` document to advertise registry metadata.
+
+Example:
+
+```
+GET https://veritrust.vc/.well-known/mcp-trust-registry.json
+```
+
+This document can contain:
+
+- Registry base URL
+- Issuer DID
+- Public key references
+- Documentation URLs
+- Framework version supported
+
+A sample structure is provided in the root README and examples.
+
+---
+
+## 10. Compatibility and Extensibility
+
+MCPF is orthogonal to MCP versions. It can be used with any MCP-compliant server.
+
+New credential types MAY be added in future versions (e.g., `MCPAgentCredential`).
+
+Future DID methods MAY be adopted in addition to `did:web`.
+
+Backward-compatible extensions SHOULD:
+
+- Reuse existing fields where possible.
+- Use additional fields under clearly namespaced keys.
+
+---
+
+## 11. Versioning
+
+MCPF uses semantic versioning:
+
+- **MAJOR** – breaking changes in the information model or required fields.
+- **MINOR** – new optional fields or capabilities that are backward compatible.
+- **PATCH** – corrections, clarifications, and documentation updates.
+
+The version of this document is **1.0 (Draft)**.
+
+---
+
+## 12. References
+
+- W3C Decentralized Identifiers (DIDs)
+- W3C Verifiable Credentials Data Model
+- Model Context Protocol (MCP) – official specification (vendor link)
+- This repository’s:
+  - `registry-api.md`
+  - `credential-schema.json`
+  - `did-profile.md`
+  - `security-considerations.md`
+
+---

--- a/specs/credential-schema.json
+++ b/specs/credential-schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritrust.vc/schemas/mcpservercredential.json",
+  "title": "MCPServerCredential",
+  "type": "object",
+  "required": [
+    "@context",
+    "type",
+    "issuer",
+    "issuedAt",
+    "validUntil",
+    "credentialSubject"
+  ],
+  "properties": {
+    "@context": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      },
+      "minItems": 1
+    },
+    "type": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      },
+      "contains": {
+        "const": "VerifiableCredential"
+      }
+    },
+    "issuer": {
+      "type": "string"
+    },
+    "issuedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "validUntil": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "credentialSubject": {
+      "type": "object",
+      "required": [
+        "id",
+        "operator",
+        "endpoint",
+        "manifest",
+        "capabilities",
+        "assuranceLevel"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "DID of the MCP server"
+        },
+        "operator": {
+          "type": "string",
+          "description": "Name of the organization operating the server"
+        },
+        "endpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "MCP endpoint URL"
+        },
+        "manifest": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to MCP manifest JSON"
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of capabilities exposed by the MCP server"
+        },
+        "assuranceLevel": {
+          "type": "string",
+          "enum": ["basic", "verified", "certified"],
+          "description": "Assurance level assigned by the issuer"
+        }
+      },
+      "additionalProperties": true
+    },
+    "proof": {
+      "type": "object",
+      "description": "Cryptographic proof object, structure depends on VC proof suite",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/specs/did-profile.md
+++ b/specs/did-profile.md
@@ -1,0 +1,110 @@
+# DID Profile for MCP Trust Framework
+
+This document describes recommendations for using Decentralized Identifiers (DIDs) within the MCP Trust Framework (MCPF).
+
+MCPF is DID-method agnostic, but early implementations are expected to use `did:web` due to simplicity and compatibility with existing web PKI.
+
+---
+
+## 1. DID Method Recommendation
+
+### 1.1. `did:web`
+
+For initial deployments, MCP servers SHOULD use `did:web` because:
+
+- It can be hosted on existing HTTPS domains.
+- It leverages established DNS and TLS infrastructure.
+- It is easy to deploy for organizations already managing web resources.
+
+Example:
+
+```text
+did:web:veritrust.vc:mcp:edgeguard-siem
+```
+
+The corresponding DID Document would be served from a URL derived from the DID method specification.
+
+---
+
+## 2. DID Document Structure
+
+A typical DID Document for an MCP server might include:
+
+- One or more `verificationMethod` entries with the server’s public keys.
+- An `assertionMethod` referencing which keys can be used for VCs.
+- `service` entries describing MCP-related endpoints.
+
+Example (simplified):
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/did/v1"],
+  "id": "did:web:veritrust.vc:mcp:edgeguard-siem",
+  "verificationMethod": [
+    {
+      "id": "did:web:veritrust.vc:mcp:edgeguard-siem#key-1",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:web:veritrust.vc:mcp:edgeguard-siem",
+      "publicKeyMultibase": "zABCDEFG1234567890"
+    }
+  ],
+  "assertionMethod": [
+    "did:web:veritrust.vc:mcp:edgeguard-siem#key-1"
+  ],
+  "service": [
+    {
+      "id": "#mcp-endpoint",
+      "type": "MCPServerEndpoint",
+      "serviceEndpoint": "https://edgeguard.cyberfort.lv/mcp"
+    },
+    {
+      "id": "#mcp-registry-entry",
+      "type": "MCPRegistryEntry",
+      "serviceEndpoint": "https://ans.veritrust.vc/mcp/servers/did:web:veritrust.vc:mcp:edgeguard-siem"
+    }
+  ]
+}
+```
+
+---
+
+## 3. Key Management
+
+Issuers and MCP Servers SHOULD:
+
+- Use modern key types (e.g., Ed25519 or secp256k1, depending on the VC proof suite).
+- Rotate keys periodically and update the DID Document accordingly.
+- Keep private keys secured in appropriate key management systems (HSM, KMS, or equivalent).
+
+Hosts verifying credentials and DID Documents MUST be prepared to:
+
+- Refresh DID Documents to pick up key rotations.
+- Handle the case where a DID is no longer resolvable or is intentionally removed.
+
+---
+
+## 4. Other DID Methods
+
+MCPF allows for the use of other DID methods, for example:
+
+- `did:key` for lightweight, self-contained identifiers.
+- `did:ion`, `did:ebsi`, or others for more advanced or regulatory-compliant settings.
+
+Implementations that support multiple DID methods should:
+
+- Clearly document which methods are supported.
+- Allow policy-based control over which DID methods are trusted.
+
+---
+
+## 5. Relationship to MCP
+
+MCP itself does not require or define DIDs. MCPF adds DIDs as an identity layer on top of MCP:
+
+- MCP servers are referenced by their DID at the trust layer.
+- MCP manifests and endpoints are linked from either:
+  - the DID Document, or
+  - the `MCPServerCredential`, or
+  - the registry entry.
+
+This separation keeps MCP simple while enabling a richer trust and governance model where needed.

--- a/specs/registry-api.md
+++ b/specs/registry-api.md
@@ -1,0 +1,328 @@
+# MCP Trust Registry API (MCPF)
+
+This document defines a simple HTTP/JSON API for an **MCP Trust Registry** compatible with the MCP Trust Framework (MCPF).
+
+The API is intentionally minimal, easy to implement, and suitable for both:
+
+- Public registries (global trust authorities)
+- Private registries (enterprise internal catalogs)
+
+Base URL is implementation-specific. In examples below, we assume:
+
+```text
+https://registry.example.com
+```
+
+All responses are JSON and use standard HTTP status codes.
+
+---
+
+## 1. Data Model Overview
+
+A Registry Entry represents one MCP server and has the structure:
+
+```json
+{
+  "did": "did:web:example.com:mcp:myserver",
+  "endpoint": "https://myserver.example.com/mcp",
+  "manifest": "https://myserver.example.com/mcp/manifest.json",
+  "credentials": [
+    "https://registry.example.com/vc/myserver.json"
+  ],
+  "metadata": {
+    "capabilities": ["telemetry", "alerts"],
+    "organization": "Example Corp",
+    "country": "US",
+    "tags": ["security", "energy"],
+    "status": "active"
+  }
+}
+```
+
+---
+
+## 2. Endpoints
+
+### 2.1. GET /mcp/servers
+
+List all MCP servers known to the registry, optionally with pagination.
+
+**Request:**
+
+```
+GET /mcp/servers?page=1&limit=50
+```
+
+**Query Parameters:**
+
+- `page` – optional, default 1
+- `limit` – optional, default 50, maximum implementation-defined
+
+**Response 200:**
+
+```json
+{
+  "page": 1,
+  "limit": 50,
+  "total": 1,
+  "items": [
+    {
+      "did": "did:web:example.com:mcp:myserver",
+      "endpoint": "https://myserver.example.com/mcp",
+      "manifest": "https://myserver.example.com/mcp/manifest.json",
+      "credentials": [
+        "https://registry.example.com/vc/myserver.json"
+      ],
+      "metadata": {
+        "capabilities": ["telemetry", "alerts"],
+        "organization": "Example Corp",
+        "country": "US",
+        "tags": ["security", "energy"],
+        "status": "active"
+      }
+    }
+  ]
+}
+```
+
+### 2.2. GET /mcp/servers/{did}
+
+Retrieve a single registry entry by DID.
+
+**Request:**
+
+```
+GET /mcp/servers/did:web:example.com:mcp:myserver
+```
+
+**Response 200:**
+
+```json
+{
+  "did": "did:web:example.com:mcp:myserver",
+  "endpoint": "https://myserver.example.com/mcp",
+  "manifest": "https://myserver.example.com/mcp/manifest.json",
+  "credentials": [
+    "https://registry.example.com/vc/myserver.json"
+  ],
+  "metadata": {
+    "capabilities": ["telemetry", "alerts"],
+    "organization": "Example Corp",
+    "country": "US",
+    "tags": ["security", "energy"],
+    "status": "active"
+  }
+}
+```
+
+**Response 404:**
+
+```json
+{
+  "error": "not_found",
+  "message": "No registry entry found for DID did:web:example.com:mcp:unknown"
+}
+```
+
+### 2.3. GET /mcp/search
+
+Search for MCP servers using simple filters.
+
+**Request:**
+
+```
+GET /mcp/search?capability=telemetry&tag=security&assuranceLevel=verified
+```
+
+**Supported Query Parameters (all optional):**
+
+- `capability` – string, match entries where `metadata.capabilities` contains this value.
+- `tag` – string, match entries where `metadata.tags` contains this value.
+- `organization` – string, match `metadata.organization` (case-insensitive).
+- `country` – string, match `metadata.country`.
+- `assuranceLevel` – string, filter by minimum assurance. Interpretation is registry-specific.
+- `issuer` – string, filter by credential issuer DID (if registry maintains such index).
+
+**Response 200:**
+
+```json
+{
+  "items": [
+    {
+      "did": "did:web:example.com:mcp:myserver",
+      "endpoint": "https://myserver.example.com/mcp",
+      "manifest": "https://myserver.example.com/mcp/manifest.json",
+      "credentials": [
+        "https://registry.example.com/vc/myserver.json"
+      ],
+      "metadata": {
+        "capabilities": ["telemetry", "alerts"],
+        "organization": "Example Corp",
+        "country": "US",
+        "tags": ["security", "energy"],
+        "status": "active"
+      }
+    }
+  ]
+}
+```
+
+### 2.4. POST /mcp/servers
+
+Register or update a registry entry.
+
+> Note: Authentication and authorization are implementation-specific. For an MVP, this may be open or protected by an API key; in production, stronger auth is recommended.
+
+**Request:**
+
+```
+POST /mcp/servers
+Content-Type: application/json
+
+{
+  "did": "did:web:example.com:mcp:myserver",
+  "endpoint": "https://myserver.example.com/mcp",
+  "manifest": "https://myserver.example.com/mcp/manifest.json",
+  "credentials": [
+    "https://registry.example.com/vc/myserver.json"
+  ],
+  "metadata": {
+    "capabilities": ["telemetry", "alerts"],
+    "organization": "Example Corp",
+    "country": "US",
+    "tags": ["security", "energy"],
+    "status": "active"
+  }
+}
+```
+
+**Response 201 (created) or 200 (updated):**
+
+```json
+{
+  "status": "ok",
+  "did": "did:web:example.com:mcp:myserver"
+}
+```
+
+**Response 400:**
+
+```json
+{
+  "error": "invalid_entry",
+  "message": "Missing required field 'did'."
+}
+```
+
+### 2.5. GET /mcp/issuers
+
+List recognized issuers (trust authorities) for credentials.
+
+**Request:**
+
+```
+GET /mcp/issuers
+```
+
+**Response 200:**
+
+```json
+{
+  "issuers": [
+    {
+      "id": "did:web:veritrust.vc",
+      "name": "Veritrust",
+      "documentation": "https://veritrust.vc/mcp-trust-framework"
+    }
+  ]
+}
+```
+
+### 2.6. GET /mcp/revocations
+
+Return a lightweight view of revoked MCP servers or credentials.
+
+**Request:**
+
+```
+GET /mcp/revocations
+```
+
+**Response 200:**
+
+```json
+{
+  "revokedServers": [
+    {
+      "did": "did:web:example.com:mcp:old-server",
+      "revokedAt": "2025-10-01T12:00:00Z",
+      "reason": "compromised_keys"
+    }
+  ],
+  "revokedCredentials": [
+    {
+      "id": "https://registry.example.com/vc/old-credential.json",
+      "revokedAt": "2025-10-01T12:00:00Z",
+      "reason": "superseded"
+    }
+  ]
+}
+```
+
+Implementations MAY provide more detailed partitioned revocation endpoints (e.g., `/mcp/revocations/servers`, `/mcp/revocations/credentials`) if needed.
+
+---
+
+## 3. Error Handling
+
+Errors SHOULD use structured JSON:
+
+```json
+{
+  "error": "string_code",
+  "message": "Human-readable explanation"
+}
+```
+
+Common error codes:
+
+- `invalid_request`
+- `not_found`
+- `invalid_entry`
+- `unauthorized`
+- `internal_error`
+
+---
+
+## 4. Authentication and Authorization
+
+The specification does not mandate a specific auth mechanism. Possible choices include:
+
+- No auth (for public read-only endpoints)
+- API keys
+- OAuth 2.0 / OpenID Connect
+- mTLS with client certificates
+
+A common pattern:
+
+- `GET` endpoints are public for read operations.
+- `POST` (and any future mutation endpoints) require authenticated access.
+
+---
+
+## 5. Extensibility
+
+Registries MAY add additional endpoints, fields, or indexes as long as:
+
+- Core fields in this spec remain stable.
+- Additional fields do not break clients that only rely on the core model.
+
+Any extensions are clearly documented.
+
+MCPF registry clients SHOULD ignore unknown fields.
+
+---
+
+## 6. Security Considerations
+
+See `security-considerations.md` for general security guidance that also applies to registry implementations.

--- a/specs/security-considerations.md
+++ b/specs/security-considerations.md
@@ -1,0 +1,165 @@
+# Security Considerations – MCP Trust Framework
+
+This document outlines security considerations for implementations of the MCP Trust Framework (MCPF), including registries, issuers, and hosts.
+
+---
+
+## 1. Key Management
+
+### 1.1. Issuer Keys
+
+Issuers (trust authorities) MUST:
+
+- Store private keys securely (HSM, KMS, or equivalent).
+- Rotate keys based on internal policies and best practices.
+- Publish updated verification material via DID Documents or other agreed mechanisms.
+
+Compromise of an issuer’s key may require:
+
+- Revoking or re-issuing affected credentials.
+- Updating trust policies and communicating with relying parties.
+
+### 1.2. Server Keys
+
+MCP servers that sign their own credentials or metadata SHOULD:
+
+- Use dedicated keys for signing.
+- Protect private keys with appropriate system protections.
+- Rotate keys and update DID Documents accordingly.
+
+---
+
+## 2. Transport Security
+
+All MCPF-related endpoints MUST use HTTPS with valid TLS certificates:
+
+- MCP endpoints (the tool APIs)
+- Registry APIs
+- Credential hosting endpoints
+- DID Document hosts
+- `.well-known` metadata endpoints
+
+Hosts SHOULD:
+
+- Reject connections with invalid or self-signed certificates, unless explicitly configured otherwise for testing.
+- Prefer modern TLS versions and cipher suites.
+
+---
+
+## 3. Revocation and Expiry
+
+### 3.1. Credential Expiry
+
+- `MCPServerCredential` includes `validUntil`.
+- Hosts MUST check that the current time is within the validity window.
+- Shorter validity periods reduce risk if a server or issuer becomes compromised.
+
+### 3.2. Revocation
+
+Registries and/or issuers SHOULD support revocation of:
+
+- Specific MCP servers
+- Specific credentials
+
+Methods may include:
+
+- Central revocation lists exposed via `GET /mcp/revocations`
+- Status endpoints for individual credentials
+- Updates to registry entries marking servers as `status: "revoked"` or `status: "inactive"`
+
+Hosts SHOULD periodically refresh revocation information and apply it during verification.
+
+---
+
+## 4. Registry Compromise
+
+If a registry is compromised, attackers may:
+
+- Insert malicious registry entries
+- Modify existing entries
+- Remove entries to hide legit servers
+
+Mitigations:
+
+- Treat registries as **indexes**, not ultimate trust sources.
+- Always verify credentials and signatures independently of the registry.
+- Allow hosts to use multiple registries or direct credentials obtained from issuers.
+- Log registry responses for audit and incident response.
+
+---
+
+## 5. Denial of Service
+
+Registries and DID/VC endpoints may be subject to DoS attacks.
+
+Implementations should:
+
+- Apply rate limiting and resource throttling.
+- Use caching of stable data (e.g., DID Documents) on the client side with reasonable TTL.
+- Implement backoff strategies on repeated failures.
+
+---
+
+## 6. Privacy
+
+Public registries may expose metadata about:
+
+- Organizations
+- Capabilities of MCP servers
+- Geographical hints (e.g., `country` fields)
+
+Where privacy is a concern:
+
+- Limit fields in public registries to non-sensitive metadata.
+- Use private registries or restricted access for sensitive environments.
+- Provide minimal disclosure in credentials.
+
+---
+
+## 7. Policy Misconfiguration
+
+Trust policies are powerful. Misconfiguration can cause:
+
+- Overly permissive access to untrusted MCP servers.
+- Overly strict policies that block legitimate operations.
+
+Recommendations:
+
+- Start with cautious defaults.
+- Provide clear policy documentation.
+- Log policy decisions (why a particular server was accepted or rejected).
+
+---
+
+## 8. Logging and Audit
+
+Hosts and registries SHOULD log:
+
+- Which MCP servers were used (by DID and endpoint).
+- Which credentials were checked and their status.
+- Policy decisions and revocation checks.
+
+Logs aid:
+
+- Forensic analysis
+- Compliance reporting
+- Security audits
+
+Care must be taken not to log sensitive data beyond what is necessary.
+
+---
+
+## 9. Implementation Bugs
+
+As with any new framework, early implementations may contain bugs.
+
+Mitigations:
+
+- Prefer simple, well-reviewed libraries.
+- Keep crypto logic as isolated as possible.
+- Add unit tests around:
+  - Credential parsing and validation
+  - Registry API interactions
+  - Policy evaluation logic
+
+Where practical, independent security review of critical components is recommended.


### PR DESCRIPTION
## Summary
- add the draft MCP Trust Framework 1.0 document outlining identity, registry, verification, and policy guidance
- document registry API endpoints along with related DID usage and security considerations
- include the MCPServerCredential JSON schema

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925704c39a0832bb8d11866a4c7e228)