### PR TITLE
Add sample registry and verification examples

### DIFF
--- a/examples/sample-did-document.json
+++ b/examples/sample-did-document.json
@@ -1,0 +1,29 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1"
+  ],
+  "id": "did:web:veritrust.vc:mcp:edgeguard-siem",
+  "verificationMethod": [
+    {
+      "id": "did:web:veritrust.vc:mcp:edgeguard-siem#key-1",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:web:veritrust.vc:mcp:edgeguard-siem",
+      "publicKeyMultibase": "zMockPublicKeyMultibaseValue"
+    }
+  ],
+  "assertionMethod": [
+    "did:web:veritrust.vc:mcp:edgeguard-siem#key-1"
+  ],
+  "service": [
+    {
+      "id": "#mcp-endpoint",
+      "type": "MCPServerEndpoint",
+      "serviceEndpoint": "https://edgeguard.cyberfort.lv/mcp"
+    },
+    {
+      "id": "#mcp-registry-entry",
+      "type": "MCPRegistryEntry",
+      "serviceEndpoint": "https://ans.veritrust.vc/mcp/servers/did:web:veritrust.vc:mcp:edgeguard-siem"
+    }
+  ]
+}

--- a/examples/sample-mcpserver-credential.json
+++ b/examples/sample-mcpserver-credential.json
@@ -1,0 +1,32 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://veritrust.vc/mcp/context.json"
+  ],
+  "type": [
+    "VerifiableCredential",
+    "MCPServerCredential"
+  ],
+  "issuer": "did:web:veritrust.vc",
+  "issuedAt": "2025-11-01T00:00:00Z",
+  "validUntil": "2027-11-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:veritrust.vc:mcp:edgeguard-siem",
+    "operator": "Cyberfort SIA",
+    "endpoint": "https://edgeguard.cyberfort.lv/mcp",
+    "manifest": "https://edgeguard.cyberfort.lv/mcp/manifest.json",
+    "capabilities": [
+      "telemetry",
+      "alerts",
+      "status"
+    ],
+    "assuranceLevel": "verified"
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2025-11-01T00:00:00Z",
+    "verificationMethod": "did:web:veritrust.vc#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "zMockSignatureBase58OrMultibaseValue"
+  }
+}

--- a/examples/sample-registry-entry.json
+++ b/examples/sample-registry-entry.json
@@ -1,0 +1,23 @@
+{
+  "did": "did:web:veritrust.vc:mcp:edgeguard-siem",
+  "endpoint": "https://edgeguard.cyberfort.lv/mcp",
+  "manifest": "https://edgeguard.cyberfort.lv/mcp/manifest.json",
+  "credentials": [
+    "https://veritrust.vc/vc/edgeguard-siem.json"
+  ],
+  "metadata": {
+    "capabilities": [
+      "telemetry",
+      "alerts",
+      "status"
+    ],
+    "organization": "Cyberfort SIA",
+    "country": "LV",
+    "tags": [
+      "security",
+      "energy",
+      "siem"
+    ],
+    "status": "active"
+  }
+}

--- a/examples/verifying-mcp-server-node.md
+++ b/examples/verifying-mcp-server-node.md
@@ -1,0 +1,183 @@
+# Verifying an MCP Server with the MCP Trust Registry (Node.js / TypeScript)
+
+This guide shows how a Node.js / TypeScript host or agent can:
+
+1. Query an MCP Trust Registry for a server by DID  
+2. Fetch its MCPServerCredential  
+3. Validate the credential structure with a JSON schema validator  
+4. Perform basic validity checks (time window, assurance level)
+
+> Note: This example does **not** perform real cryptographic signature verification.
+
+---
+
+## 1. Setup
+
+Install dependencies:
+
+```bash
+npm install node-fetch ajv ajv-formats
+# or
+pnpm add node-fetch ajv ajv-formats
+```
+
+Assume:
+
+```
+Registry: https://registry.example.com
+DID:      did:web:veritrust.vc:mcp:edgeguard-siem
+```
+
+In Node 18+, you can use the built-in fetch.
+If you’re on older Node, configure node-fetch as needed.
+
+## 2. Fetch Registry Entry
+
+Example TypeScript file, verify-mcp-server.ts:
+
+```typescript
+import fetch from "node-fetch";
+
+const REGISTRY_BASE_URL = "https://registry.example.com";
+const SERVER_DID = "did:web:veritrust.vc:mcp:edgeguard-siem";
+
+async function fetchRegistryEntry(did: string): Promise<any> {
+  const url = `${REGISTRY_BASE_URL}/mcp/servers/${encodeURIComponent(did)}`;
+  const resp = await fetch(url, { method: "GET" });
+
+  if (resp.status === 404) {
+    throw new Error(`No registry entry found for DID ${did}`);
+  }
+  if (!resp.ok) {
+    throw new Error(`Registry error: ${resp.status} ${resp.statusText}`);
+  }
+
+  return resp.json();
+}
+
+(async () => {
+  const entry = await fetchRegistryEntry(SERVER_DID);
+  console.log("Registry entry:", entry);
+})();
+```
+
+## 3. Fetch MCPServerCredential
+
+```typescript
+async function fetchCredential(entry: any): Promise<any> {
+  const creds: string[] = entry.credentials || [];
+  if (!creds.length) {
+    throw new Error("Registry entry has no 'credentials' URLs");
+  }
+
+  const credUrl = creds[0];
+  const resp = await fetch(credUrl, { method: "GET" });
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch credential: ${resp.status} ${resp.statusText}`);
+  }
+
+  return resp.json();
+}
+
+(async () => {
+  const entry = await fetchRegistryEntry(SERVER_DID);
+  const credential = await fetchCredential(entry);
+  console.log("Credential:", credential);
+})();
+```
+
+## 4. Validate Credential Structure with AJV
+
+Place credential-schema.json (from specs/) where it can be imported or loaded.
+For simplicity here, assume we load it from a file.
+
+```typescript
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+function loadSchema(): any {
+  const schemaPath = resolve(__dirname, "../specs/credential-schema.json");
+  const raw = readFileSync(schemaPath, "utf-8");
+  return JSON.parse(raw);
+}
+
+function validateCredentialStructure(credential: any, schema: any): void {
+  const ajv = new Ajv({ allErrors: true });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(credential);
+  if (!valid) {
+    const errors = (validate.errors || [])
+      .map((e) => `- ${e.instancePath || "/"} ${e.message}`)
+      .join("\n");
+    throw new Error(`Credential does not conform to schema:\n${errors}`);
+  }
+}
+```
+
+## 5. Basic Validity Checks
+
+```typescript
+function parseIsoDateTime(value: string): Date {
+  // Node Date supports ISO 8601 with Z or offset
+  const d = new Date(value);
+  if (isNaN(d.getTime())) {
+    throw new Error(`Invalid date-time: ${value}`);
+  }
+  return d;
+}
+
+function isCredentialValidNow(credential: any, now: Date = new Date()): boolean {
+  const issuedAt = parseIsoDateTime(credential.issuedAt);
+  const validUntil = parseIsoDateTime(credential.validUntil);
+
+  return issuedAt <= now && now <= validUntil;
+}
+
+function checkAssuranceLevel(credential: any, minimumLevel: string = "basic"): boolean {
+  const levels = ["basic", "verified", "certified"];
+  const subject = credential.credentialSubject || {};
+  const level = subject.assuranceLevel || "basic";
+
+  const minIndex = levels.indexOf(minimumLevel);
+  const levelIndex = levels.indexOf(level);
+
+  if (minIndex === -1 || levelIndex === -1) {
+    return false;
+  }
+  return levelIndex >= minIndex;
+}
+```
+
+## 6. Putting It All Together
+
+```typescript
+(async () => {
+  try {
+    const entry = await fetchRegistryEntry(SERVER_DID);
+    const credential = await fetchCredential(entry);
+
+    const schema = loadSchema();
+    validateCredentialStructure(credential, schema);
+
+    const now = new Date();
+    if (!isCredentialValidNow(credential, now)) {
+      throw new Error("Credential is not within its validity period.");
+    }
+
+    if (!checkAssuranceLevel(credential, "verified")) {
+      throw new Error("Credential assurance level is below required minimum.");
+    }
+
+    console.log("Credential is structurally valid, current, and meets assurance requirements.");
+    console.log("MCP server can be considered trusted according to this basic policy.");
+
+    // TODO: integrate this result into your MCP host's tool enablement logic.
+  } catch (err: any) {
+    console.error("Verification failed:", err.message || err);
+    process.exit(1);
+  }
+})();
+```

--- a/examples/verifying-mcp-server-python.md
+++ b/examples/verifying-mcp-server-python.md
@@ -1,0 +1,174 @@
+# Verifying an MCP Server with the MCP Trust Registry (Python)
+
+This guide shows how a Python host or agent can:
+
+1. Query an MCP Trust Registry for a server by DID
+2. Fetch its MCPServerCredential
+3. Validate the credential structure
+4. Perform basic validity checks (time window, assurance level)
+
+> Note: This example does **not** perform real cryptographic signature verification.  
+> That is left as an exercise for production environments.
+
+---
+
+## 1. Setup
+
+Install dependencies (using `pip`):
+
+```bash
+pip install requests jsonschema
+```
+
+Assume the registry is running at:
+
+```
+https://registry.example.com
+```
+
+and the MCP server DID is:
+
+```
+did:web:veritrust.vc:mcp:edgeguard-siem
+```
+
+## 2. Fetch Registry Entry
+
+```python
+import requests
+
+REGISTRY_BASE_URL = "https://registry.example.com"
+SERVER_DID = "did:web:veritrust.vc:mcp:edgeguard-siem"
+
+
+def fetch_registry_entry(did: str) -> dict:
+    url = f"{REGISTRY_BASE_URL}/mcp/servers/{did}"
+    resp = requests.get(url, timeout=5)
+    if resp.status_code == 404:
+        raise ValueError(f"No registry entry found for DID {did}")
+    resp.raise_for_status()
+    return resp.json()
+
+
+if __name__ == "__main__":
+    entry = fetch_registry_entry(SERVER_DID)
+    print("Registry entry:")
+    print(entry)
+```
+
+## 3. Fetch MCPServerCredential
+
+The registry entry contains a credentials array with URLs to credentials.
+
+```python
+def fetch_credential(entry: dict) -> dict:
+    creds = entry.get("credentials") or []
+    if not creds:
+        raise ValueError("Registry entry has no 'credentials' URLs")
+
+    # Use the first credential URL for this example
+    cred_url = creds[0]
+    resp = requests.get(cred_url, timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+if __name__ == "__main__":
+    entry = fetch_registry_entry(SERVER_DID)
+    credential = fetch_credential(entry)
+    print("Credential:")
+    print(credential)
+```
+
+## 4. Validate Credential Structure with JSON Schema
+
+Use the credential-schema.json from specs/ to validate basic structure.
+
+```python
+import json
+from jsonschema import Draft202012Validator
+from pathlib import Path
+
+
+def load_schema() -> dict:
+    schema_path = Path(__file__).resolve().parent.parent / "specs" / "credential-schema.json"
+    with open(schema_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate_credential_structure(credential: dict, schema: dict) -> None:
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(credential), key=lambda e: e.path)
+    if errors:
+        msg = "\n".join(f"- {'/'.join(map(str, err.path))}: {err.message}" for err in errors)
+        raise ValueError(f"Credential does not conform to schema:\n{msg}")
+
+
+if __name__ == "__main__":
+    entry = fetch_registry_entry(SERVER_DID)
+    credential = fetch_credential(entry)
+    schema = load_schema()
+    validate_credential_structure(credential, schema)
+    print("Credential structure is valid according to schema.")
+```
+
+## 5. Basic Validity Checks (Time Window, Assurance Level)
+
+```python
+from datetime import datetime, timezone
+
+
+def parse_iso8601(dt_str: str) -> datetime:
+    # Minimal parser assuming 'Z' or full offset
+    return datetime.fromisoformat(dt_str.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def is_credential_valid_now(credential: dict, now: datetime | None = None) -> bool:
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    issued_at = parse_iso8601(credential["issuedAt"])
+    valid_until = parse_iso8601(credential["validUntil"])
+
+    return issued_at <= now <= valid_until
+
+
+def check_assurance_level(credential: dict, minimum_level: str = "basic") -> bool:
+    levels = ["basic", "verified", "certified"]
+    min_index = levels.index(minimum_level)
+
+    subject = credential.get("credentialSubject", {})
+    level = subject.get("assuranceLevel", "basic")
+    try:
+        level_index = levels.index(level)
+    except ValueError:
+        return False
+
+    return level_index >= min_index
+
+
+if __name__ == "__main__":
+    entry = fetch_registry_entry(SERVER_DID)
+    credential = fetch_credential(entry)
+    schema = load_schema()
+    validate_credential_structure(credential, schema)
+
+    now = datetime.now(timezone.utc)
+
+    if not is_credential_valid_now(credential, now):
+        raise ValueError("Credential is not within its validity period.")
+
+    if not check_assurance_level(credential, minimum_level="verified"):
+        raise ValueError("Credential assurance level is below required minimum.")
+
+    print("Credential is structurally valid, current, and meets assurance requirements.")
+```
+
+## 6. Next Steps
+
+In a production implementation, you SHOULD:
+
+- Implement full cryptographic proof verification.
+- Enforce your organization’s trust policy (allowed issuers, DID methods, countries, etc.).
+- Add caching for registry responses and credentials.
+- Integrate with actual MCP host logic to decide whether to enable the server as a tool.


### PR DESCRIPTION
## Summary
- add sample registry entry, credential, and DID document JSON files
- provide Python and Node.js guides for verifying MCP server credentials

## Testing
- not run (documentation and sample data only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692573621ff0832b804e855c7e43e614)