### PR TITLE
Add FastAPI registry reference implementation

### DIFF
--- a/registry-reference-implementation/Dockerfile
+++ b/registry-reference-implementation/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# Install system dependencies if needed later
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source
+COPY src ./src
+
+WORKDIR /app/src
+
+EXPOSE 8080
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/registry-reference-implementation/README.md
+++ b/registry-reference-implementation/README.md
@@ -1,0 +1,110 @@
+# MCP Trust Registry – Reference Implementation (FastAPI)
+
+This is a minimal reference implementation of an **MCP Trust Registry** compatible with the **MCP Trust Framework (MCPF)**.
+
+It provides:
+
+- A simple in-memory registry of MCP servers
+- HTTP API as specified in `specs/registry-api.md`
+- Preloaded example entry from `examples/sample-registry-entry.json`
+
+> ⚠️ This implementation is **for demonstration and testing**.  
+> It does **not** implement authentication, cryptographic verification, or persistent storage.
+
+---
+
+## 1. Requirements
+
+- Python 3.10 or newer
+- `pip` or `uv` / `pipx`
+- Optionally Docker & docker-compose
+
+---
+
+## 2. Install and Run (Directly with Python)
+
+From the repository root:
+
+```bash
+cd registry-reference-implementation
+
+# (Optional) create and activate a virtualenv
+python -m venv .venv
+source .venv/bin/activate  # on Windows: .venv\Scripts\activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+
+Run the service:
+
+cd src
+uvicorn main:app --host 0.0.0.0 --port 8080 --reload
+
+
+The registry will be available at:
+
+http://localhost:8080
+
+
+Key endpoints:
+
+GET /mcp/servers
+
+GET /mcp/servers/{did}
+
+GET /mcp/search
+
+POST /mcp/servers
+
+GET /mcp/issuers
+
+GET /mcp/revocations
+
+3. Install and Run with Docker
+
+From the repository root:
+
+cd registry-reference-implementation
+docker-compose up --build
+
+
+The registry will listen on:
+
+http://localhost:8080
+
+4. Example Calls
+
+List servers:
+
+curl http://localhost:8080/mcp/servers
+
+
+Get one server by DID:
+
+curl "http://localhost:8080/mcp/servers/did:web:veritrust.vc:mcp:edgeguard-siem"
+
+
+Search by capability:
+
+curl "http://localhost:8080/mcp/search?capability=telemetry"
+
+
+Register a new server:
+
+curl -X POST http://localhost:8080/mcp/servers \
+  -H "Content-Type: application/json" \
+  -d @../examples/sample-registry-entry.json
+
+5. Notes
+
+Storage is in-memory only; restarting the service will reset the data.
+
+On startup, the registry will attempt to load:
+
+../examples/sample-registry-entry.json if present.
+
+Authentication and cryptographic verification are intentionally out-of-scope for this MVP.
+
+
+---

--- a/registry-reference-implementation/docker-compose.yml
+++ b/registry-reference-implementation/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  registry:
+    build: .
+    container_name: mcp-trust-registry
+    ports:
+      - "8080:8080"
+    environment:
+      - REGISTRY_NAME=Veritrust MCP Trust Registry
+      - REGISTRY_BASE_URL=http://localhost:8080
+    restart: unless-stopped

--- a/registry-reference-implementation/requirements.txt
+++ b/registry-reference-implementation/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.0
+pydantic==2.9.0
+python-dotenv==1.0.1
+
+
+(Exact versions can be adjusted, but these are reasonable.)

--- a/registry-reference-implementation/src/__init__.py
+++ b/registry-reference-implementation/src/__init__.py
@@ -1,0 +1,1 @@
+# Empty file to mark this directory as a Python package (optional for this layout).

--- a/registry-reference-implementation/src/config.py
+++ b/registry-reference-implementation/src/config.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+import os
+
+
+class Settings(BaseModel):
+    registry_name: str = "MCP Trust Registry (Reference Implementation)"
+    base_url: str = "http://localhost:8080"
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        return cls(
+            registry_name=os.getenv("REGISTRY_NAME", cls.__fields__["registry_name"].default),
+            base_url=os.getenv("REGISTRY_BASE_URL", cls.__fields__["base_url"].default),
+        )
+
+
+settings = Settings.from_env()

--- a/registry-reference-implementation/src/main.py
+++ b/registry-reference-implementation/src/main.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+
+from models import (
+    RegistryEntry,
+    PaginatedServers,
+    SearchResults,
+    Issuer,
+    RevocationStatus,
+    ErrorResponse,
+)
+from storage import InMemoryStorage
+from config import settings
+
+from pathlib import Path
+import json
+
+app = FastAPI(
+    title="MCP Trust Registry (Reference Implementation)",
+    description="Minimal reference registry implementing the MCP Trust Framework (MCPF) API.",
+    version="0.1.0",
+)
+
+# Allow CORS from anywhere for simplicity in the reference implementation
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+storage = InMemoryStorage()
+
+
+def _load_example_entry() -> None:
+    """
+    Try to load the sample registry entry from ../../examples/sample-registry-entry.json
+    and add a default issuer.
+    """
+    try:
+        # from src/main.py → go two levels up to repo root
+        base = Path(__file__).resolve().parents[2]
+        example_path = base / "examples" / "sample-registry-entry.json"
+        if example_path.is_file():
+            with example_path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            entry = RegistryEntry(**data)
+            storage.upsert_server(entry)
+            print(f"[startup] Loaded example registry entry from {example_path}")
+        else:
+            print(f"[startup] No example registry entry found at {example_path}")
+    except Exception as exc:
+        print(f"[startup] Failed to load example registry entry: {exc!r}")
+
+    # Add a default issuer for demonstration purposes
+    storage.add_issuer(
+        Issuer(
+            id="did:web:veritrust.vc",
+            name="Veritrust",
+            documentation=settings.base_url,
+        )
+    )
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    _load_example_entry()
+
+
+# --- API endpoints ---
+
+
+@app.get(
+    "/mcp/servers",
+    response_model=PaginatedServers,
+    responses={500: {"model": ErrorResponse}},
+)
+async def list_servers(
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=500),
+):
+    servers = storage.list_servers()
+    total = len(servers)
+
+    start = (page - 1) * limit
+    end = start + limit
+    items = servers[start:end]
+
+    return PaginatedServers(page=page, limit=limit, total=total, items=items)
+
+
+@app.get(
+    "/mcp/servers/{did}",
+    response_model=RegistryEntry,
+    responses={
+        404: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+)
+async def get_server(did: str):
+    entry = storage.get_server(did)
+    if not entry:
+        raise HTTPException(
+            status_code=404,
+            detail=ErrorResponse(
+                error="not_found",
+                message=f"No registry entry found for DID {did}",
+            ).model_dump(),
+        )
+    return entry
+
+
+@app.get(
+    "/mcp/search",
+    response_model=SearchResults,
+    responses={500: {"model": ErrorResponse}},
+)
+async def search_servers(
+    capability: Optional[str] = Query(None),
+    tag: Optional[str] = Query(None),
+    organization: Optional[str] = Query(None),
+    country: Optional[str] = Query(None),
+):
+    results = storage.search_servers(
+        capability=capability,
+        tag=tag,
+        organization=organization,
+        country=country,
+    )
+    return SearchResults(items=results)
+
+
+@app.post(
+    "/mcp/servers",
+    response_model=dict,
+    responses={400: {"model": ErrorResponse}, 500: {"model": ErrorResponse}},
+)
+async def upsert_server(entry: RegistryEntry):
+    # In a real implementation, this would be authenticated and validated further
+    storage.upsert_server(entry)
+    return {"status": "ok", "did": entry.did}
+
+
+@app.get(
+    "/mcp/issuers",
+    response_model=dict,
+    responses={500: {"model": ErrorResponse}},
+)
+async def list_issuers():
+    issuers = storage.list_issuers()
+    return {"issuers": issuers}
+
+
+@app.get(
+    "/mcp/revocations",
+    response_model=RevocationStatus,
+    responses={500: {"model": ErrorResponse}},
+)
+async def list_revocations():
+    return storage.list_revocations()

--- a/registry-reference-implementation/src/models.py
+++ b/registry-reference-implementation/src/models.py
@@ -1,0 +1,65 @@
+from typing import List, Optional, Dict, Any
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class Metadata(BaseModel):
+    capabilities: List[str] = Field(default_factory=list)
+    organization: Optional[str] = None
+    country: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    status: Optional[str] = Field(
+        default="active", description="e.g. active, inactive, revoked"
+    )
+
+
+class RegistryEntry(BaseModel):
+    did: str = Field(..., description="DID of the MCP server")
+    endpoint: HttpUrl = Field(..., description="MCP endpoint URL")
+    manifest: HttpUrl = Field(..., description="MCP manifest URL")
+    credentials: List[HttpUrl] = Field(
+        default_factory=list,
+        description="URLs to MCPServerCredential verifiable credentials",
+    )
+    metadata: Metadata = Field(default_factory=Metadata)
+
+
+class Issuer(BaseModel):
+    id: str = Field(..., description="Identifier of issuer, usually a DID")
+    name: str = Field(..., description="Human-readable name of the issuer")
+    documentation: Optional[HttpUrl] = Field(
+        default=None, description="Link to issuer documentation"
+    )
+
+
+class RevokedServer(BaseModel):
+    did: str
+    revokedAt: str
+    reason: Optional[str] = None
+
+
+class RevokedCredential(BaseModel):
+    id: HttpUrl
+    revokedAt: str
+    reason: Optional[str] = None
+
+
+class RevocationStatus(BaseModel):
+    revokedServers: List[RevokedServer] = Field(default_factory=list)
+    revokedCredentials: List[RevokedCredential] = Field(default_factory=list)
+
+
+class PaginatedServers(BaseModel):
+    page: int
+    limit: int
+    total: int
+    items: List[RegistryEntry]
+
+
+class SearchResults(BaseModel):
+    items: List[RegistryEntry] = Field(default_factory=list)
+
+
+class ErrorResponse(BaseModel):
+    error: str
+    message: str
+    details: Optional[Dict[str, Any]] = None

--- a/registry-reference-implementation/src/storage.py
+++ b/registry-reference-implementation/src/storage.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+from datetime import datetime, timezone
+
+from models import (
+    RegistryEntry,
+    Issuer,
+    RevocationStatus,
+    RevokedServer,
+    RevokedCredential,
+)
+
+
+class InMemoryStorage:
+    """
+    Simple in-memory storage for registry entries, issuers, and revocations.
+
+    This is not concurrent-safe or persistent; it is intended only for
+    demonstration and testing of the API and data model.
+    """
+
+    def __init__(self) -> None:
+        self._servers: Dict[str, RegistryEntry] = {}
+        self._issuers: List[Issuer] = []
+        self._revoked_servers: List[RevokedServer] = []
+        self._revoked_credentials: List[RevokedCredential] = []
+
+    # --- MCP Servers ---
+
+    def list_servers(self) -> List[RegistryEntry]:
+        return list(self._servers.values())
+
+    def get_server(self, did: str) -> Optional[RegistryEntry]:
+        return self._servers.get(did)
+
+    def upsert_server(self, entry: RegistryEntry) -> None:
+        self._servers[entry.did] = entry
+
+    def search_servers(
+        self,
+        capability: Optional[str] = None,
+        tag: Optional[str] = None,
+        organization: Optional[str] = None,
+        country: Optional[str] = None,
+    ) -> List[RegistryEntry]:
+        results: List[RegistryEntry] = []
+        for entry in self._servers.values():
+            meta = entry.metadata
+
+            if capability and capability not in (meta.capabilities or []):
+                continue
+            if tag and tag not in (meta.tags or []):
+                continue
+            if organization and (meta.organization or "").lower() != organization.lower():
+                continue
+            if country and (meta.country or "").upper() != country.upper():
+                continue
+
+            results.append(entry)
+
+        return results
+
+    # --- Issuers ---
+
+    def list_issuers(self) -> List[Issuer]:
+        return list(self._issuers)
+
+    def add_issuer(self, issuer: Issuer) -> None:
+        self._issuers.append(issuer)
+
+    # --- Revocations ---
+
+    def list_revocations(self) -> RevocationStatus:
+        return RevocationStatus(
+            revokedServers=list(self._revoked_servers),
+            revokedCredentials=list(self._revoked_credentials),
+        )
+
+    def revoke_server(self, did: str, reason: Optional[str] = None) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        self._revoked_servers.append(
+            RevokedServer(did=did, revokedAt=now, reason=reason)
+        )
+
+    def revoke_credential(self, cred_id: str, reason: Optional[str] = None) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        self._revoked_credentials.append(
+            RevokedCredential(id=cred_id, revokedAt=now, reason=reason)
+        )


### PR DESCRIPTION
## Summary
- add FastAPI reference implementation for the MCP trust registry with in-memory storage
- document usage instructions and example API interactions
- provide containerization assets and dependency requirements for running the service

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257cc2eae0832b973e7582461e8eb1)