### PR TITLE
Add Python SDK for MCP Trust Framework

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,0 +1,98 @@
+# mcpf-client (Python SDK)
+
+A minimal Python SDK for interacting with an **MCP Trust Registry** that implements the **MCP Trust Framework (MCPF)**.
+
+This SDK helps you:
+
+- Query MCP registry endpoints
+- Retrieve registry entries by DID
+- Search for MCP servers by metadata
+- Perform basic validation of MCPServerCredentials (time window, assurance level)
+
+> ⚠️ This SDK does **not** implement full cryptographic verification of Verifiable Credentials.  
+> It focuses on structure and simple policy checks.
+
+---
+
+## Installation
+
+For local development (inside this monorepo), you can install in editable mode:
+
+```bash
+cd sdks/python
+pip install -e .
+```
+
+This will install the package as `mcpf_client`.
+
+## Quick Start
+
+```python
+from mcpf_client import RegistryClient
+from mcpf_client.verification import is_credential_valid_now, check_assurance_level
+import requests
+
+REGISTRY_URL = "http://localhost:8080"
+SERVER_DID = "did:web:veritrust.vc:mcp:edgeguard-siem"
+
+client = RegistryClient(base_url=REGISTRY_URL)
+
+# 1. Get registry entry by DID
+entry = client.get_server(SERVER_DID)
+print("Registry entry:", entry)
+
+# 2. Fetch MCPServerCredential (first URL in entry.credentials)
+if not entry.credentials:
+    raise RuntimeError("No credentials listed for this server.")
+cred_url = entry.credentials[0]
+credential = requests.get(cred_url, timeout=5).json()
+
+# 3. Simple validity checks
+if not is_credential_valid_now(credential):
+    raise RuntimeError("Credential is not within its validity period.")
+
+if not check_assurance_level(credential, minimum_level="verified"):
+    raise RuntimeError("Credential assurance level is below required minimum.")
+
+print("Credential is current and meets assurance requirements.")
+```
+
+## API Overview
+
+### RegistryClient
+
+```python
+from mcpf_client import RegistryClient
+
+client = RegistryClient(base_url="http://localhost:8080")
+
+# List servers
+page = client.list_servers(page=1, limit=50)
+
+# Get server by DID
+entry = client.get_server("did:web:example.com:mcp:myserver")
+
+# Search servers
+results = client.search_servers(capability="telemetry", tag="security")
+```
+
+### Verification helpers
+
+Located in `mcpf_client.verification`:
+
+- `is_credential_valid_now(credential: dict, now: datetime | None = None) -> bool`
+- `check_assurance_level(credential: dict, minimum_level: str = "basic") -> bool`
+- `validate_credential_structure(credential: dict, schema: dict) -> None` (uses `jsonschema` if installed, otherwise raises `ImportError`)
+
+## Limitations
+
+- Does not perform VC signature verification.
+- Does not manage caching or complex trust policies.
+- Intended as a simple building block for hosts/agents that want to integrate with an MCP Trust Registry.
+
+For production use, you should:
+
+- Implement full VC proof verification.
+- Integrate your organization’s trust policies.
+- Add caching and error handling around network calls.
+

--- a/sdks/python/mcpf_client/__init__.py
+++ b/sdks/python/mcpf_client/__init__.py
@@ -1,0 +1,30 @@
+"""
+mcpf_client
+
+Python SDK for interacting with MCP Trust Framework registries.
+"""
+
+from .client import RegistryClient
+from .models import (
+    Metadata,
+    RegistryEntry,
+    PaginatedServers,
+    SearchResults,
+    Issuer,
+    RevokedServer,
+    RevokedCredential,
+    RevocationStatus,
+)
+
+__all__ = [
+    "RegistryClient",
+    "Metadata",
+    "RegistryEntry",
+    "PaginatedServers",
+    "SearchResults",
+    "Issuer",
+    "RevokedServer",
+    "RevokedCredential",
+    "RevocationStatus",
+]
+

--- a/sdks/python/mcpf_client/client.py
+++ b/sdks/python/mcpf_client/client.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import Optional, Dict, Any
+import requests
+
+from .models import (
+    RegistryEntry,
+    PaginatedServers,
+    SearchResults,
+    RevocationStatus,
+    Issuer,
+)
+
+
+class RegistryClient:
+    """
+    Client for interacting with an MCP Trust Registry that implements
+    the MCP Trust Framework (MCPF) API.
+    """
+
+    def __init__(self, base_url: str, session: Optional[requests.Session] = None) -> None:
+        """
+        :param base_url: Base URL of the registry, e.g. "http://localhost:8080"
+        :param session: Optional requests.Session for connection pooling and custom config.
+        """
+        self.base_url = base_url.rstrip("/")
+        self.session = session or requests.Session()
+
+    # --- Low-level request helper ---
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        resp = self.session.get(url, params=params, timeout=10)
+        if not resp.ok:
+            try:
+                detail = resp.json()
+            except Exception:
+                detail = {"error": resp.text}
+            raise RuntimeError(
+                f"Registry GET {path} failed: {resp.status_code} {resp.reason} – {detail}"
+            )
+        return resp.json()
+
+    def _post(self, path: str, json_body: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        resp = self.session.post(url, json=json_body, timeout=10)
+        if not resp.ok:
+            try:
+                detail = resp.json()
+            except Exception:
+                detail = {"error": resp.text}
+            raise RuntimeError(
+                f"Registry POST {path} failed: {resp.status_code} {resp.reason} – {detail}"
+            )
+        return resp.json()
+
+    # --- High-level API methods ---
+
+    def list_servers(self, page: int = 1, limit: int = 50) -> PaginatedServers:
+        """
+        List MCP servers known to the registry.
+
+        :param page: page number, starting at 1
+        :param limit: number of items per page
+        """
+        data = self._get("/mcp/servers", params={"page": page, "limit": limit})
+        return PaginatedServers.from_dict(data)
+
+    def get_server(self, did: str) -> RegistryEntry:
+        """
+        Get a single MCP server registry entry by DID.
+
+        :param did: DID of the MCP server
+        """
+        data = self._get(f"/mcp/servers/{did}")
+        return RegistryEntry.from_dict(data)
+
+    def search_servers(
+        self,
+        capability: Optional[str] = None,
+        tag: Optional[str] = None,
+        organization: Optional[str] = None,
+        country: Optional[str] = None,
+    ) -> SearchResults:
+        """
+        Search for MCP servers by simple metadata filters.
+        """
+        params: Dict[str, Any] = {}
+        if capability:
+            params["capability"] = capability
+        if tag:
+            params["tag"] = tag
+        if organization:
+            params["organization"] = organization
+        if country:
+            params["country"] = country
+
+        data = self._get("/mcp/search", params=params)
+        return SearchResults.from_dict(data)
+
+    def upsert_server(self, entry: RegistryEntry) -> Dict[str, Any]:
+        """
+        Register or update a registry entry.
+
+        NOTE: In real deployments, this would typically require authentication.
+        """
+        body = {
+            "did": entry.did,
+            "endpoint": entry.endpoint,
+            "manifest": entry.manifest,
+            "credentials": entry.credentials,
+            "metadata": {
+                "capabilities": entry.metadata.capabilities,
+                "organization": entry.metadata.organization,
+                "country": entry.metadata.country,
+                "tags": entry.metadata.tags,
+                "status": entry.metadata.status,
+            },
+        }
+        return self._post("/mcp/servers", json_body=body)
+
+    def list_issuers(self) -> Dict[str, Any]:
+        """
+        Return raw issuer information from the registry.
+        Caller can cast to Issuer objects if desired.
+        """
+        data = self._get("/mcp/issuers")
+        issuers_raw = data.get("issuers", [])
+        issuers = [Issuer.from_dict(d) for d in issuers_raw]
+        return {"issuers": issuers}
+
+    def get_revocations(self) -> RevocationStatus:
+        """
+        Get revoked servers and credentials as reported by the registry.
+        """
+        data = self._get("/mcp/revocations")
+        return RevocationStatus.from_dict(data)
+

--- a/sdks/python/mcpf_client/models.py
+++ b/sdks/python/mcpf_client/models.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict, Any
+
+
+@dataclass
+class Metadata:
+    capabilities: List[str] = field(default_factory=list)
+    organization: Optional[str] = None
+    country: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+    status: Optional[str] = "active"
+
+
+@dataclass
+class RegistryEntry:
+    did: str
+    endpoint: str
+    manifest: str
+    credentials: List[str] = field(default_factory=list)
+    metadata: Metadata = field(default_factory=Metadata)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RegistryEntry":
+        meta_data = data.get("metadata") or {}
+        metadata = Metadata(
+            capabilities=meta_data.get("capabilities") or [],
+            organization=meta_data.get("organization"),
+            country=meta_data.get("country"),
+            tags=meta_data.get("tags") or [],
+            status=meta_data.get("status"),
+        )
+        return cls(
+            did=data["did"],
+            endpoint=data["endpoint"],
+            manifest=data["manifest"],
+            credentials=data.get("credentials") or [],
+            metadata=metadata,
+        )
+
+
+@dataclass
+class Issuer:
+    id: str
+    name: str
+    documentation: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Issuer":
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            documentation=data.get("documentation"),
+        )
+
+
+@dataclass
+class RevokedServer:
+    did: str
+    revokedAt: str
+    reason: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RevokedServer":
+        return cls(
+            did=data["did"],
+            revokedAt=data["revokedAt"],
+            reason=data.get("reason"),
+        )
+
+
+@dataclass
+class RevokedCredential:
+    id: str
+    revokedAt: str
+    reason: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RevokedCredential":
+        return cls(
+            id=data["id"],
+            revokedAt=data["revokedAt"],
+            reason=data.get("reason"),
+        )
+
+
+@dataclass
+class RevocationStatus:
+    revokedServers: List[RevokedServer] = field(default_factory=list)
+    revokedCredentials: List[RevokedCredential] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RevocationStatus":
+        servers = [RevokedServer.from_dict(d) for d in data.get("revokedServers", [])]
+        creds = [RevokedCredential.from_dict(d) for d in data.get("revokedCredentials", [])]
+        return cls(revokedServers=servers, revokedCredentials=creds)
+
+
+@dataclass
+class PaginatedServers:
+    page: int
+    limit: int
+    total: int
+    items: List[RegistryEntry]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PaginatedServers":
+        items = [RegistryEntry.from_dict(d) for d in data.get("items", [])]
+        return cls(
+            page=data.get("page", 1),
+            limit=data.get("limit", len(items)),
+            total=data.get("total", len(items)),
+            items=items,
+        )
+
+
+@dataclass
+class SearchResults:
+    items: List[RegistryEntry]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SearchResults":
+        items = [RegistryEntry.from_dict(d) for d in data.get("items", [])]
+        return cls(items=items)
+

--- a/sdks/python/mcpf_client/verification.py
+++ b/sdks/python/mcpf_client/verification.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+
+def _parse_iso8601(dt_str: str) -> datetime:
+    """
+    Minimal ISO 8601 parser that understands 'Z' and timezone offsets.
+    """
+    return datetime.fromisoformat(dt_str.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def is_credential_valid_now(credential: Dict[str, Any], now: Optional[datetime] = None) -> bool:
+    """
+    Check if the MCPServerCredential is within its validity window.
+
+    :param credential: Credential dict containing 'issuedAt' and 'validUntil'
+    :param now: Optional datetime. If None, uses current UTC time.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    issued_at_str = credential.get("issuedAt")
+    valid_until_str = credential.get("validUntil")
+
+    if not issued_at_str or not valid_until_str:
+        return False
+
+    try:
+        issued_at = _parse_iso8601(issued_at_str)
+        valid_until = _parse_iso8601(valid_until_str)
+    except Exception:
+        return False
+
+    return issued_at <= now <= valid_until
+
+
+def check_assurance_level(
+    credential: Dict[str, Any],
+    minimum_level: str = "basic",
+) -> bool:
+    """
+    Check if the credential's assuranceLevel meets or exceeds the given minimum.
+
+    Levels (from lowest to highest):
+      - basic
+      - verified
+      - certified
+    """
+    levels = ["basic", "verified", "certified"]
+
+    subject = credential.get("credentialSubject", {})
+    level = subject.get("assuranceLevel", "basic")
+
+    try:
+        min_index = levels.index(minimum_level)
+        level_index = levels.index(level)
+    except ValueError:
+        return False
+
+    return level_index >= min_index
+
+
+def validate_credential_structure(credential: Dict[str, Any], schema: Dict[str, Any]) -> None:
+    """
+    Validate the credential against the given JSON Schema.
+
+    This uses the 'jsonschema' library if available. If the library is not installed,
+    this function will raise an ImportError.
+
+    :param credential: Credential dictionary to validate.
+    :param schema: JSON Schema dictionary.
+    :raises ValueError: if the credential does not conform to the schema.
+    :raises ImportError: if jsonschema is not installed.
+    """
+    try:
+        from jsonschema import Draft202012Validator  # type: ignore
+    except ImportError as exc:
+        raise ImportError(
+            "jsonschema is required for validate_credential_structure. "
+            "Install it via 'pip install jsonschema'."
+        ) from exc
+
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(credential), key=lambda e: e.path)
+    if errors:
+        msg_lines = [
+            f"- {'/'.join(map(str, err.path))}: {err.message}" for err in errors
+        ]
+        msg = "\n".join(msg_lines)
+        raise ValueError(f"Credential does not conform to schema:\n{msg}")
+

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mcpf-client"
+version = "0.1.0"
+description = "Python client SDK for MCP Trust Framework registries"
+authors = [
+  { name = "Veritrust", email = "info@veritrust.vc" }
+]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "requests>=2.31.0"
+]
+
+[project.urls]
+Homepage = "https://github.com/Veritrust-VC/mcp-trust-framework"
+Repository = "https://github.com/Veritrust-VC/mcp-trust-framework"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["mcpf_client*"]
+


### PR DESCRIPTION
## Summary
- add Python SDK package with registry client, data models, and verification utilities
- document installation, quick start, and API overview for the Python SDK

## Testing
- python -m compileall sdks/python


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692583a30d9c832babc6dfe2e1606d97)