### PR TITLE
Add initial Node TypeScript SDK scaffold

### DIFF
--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -1,0 +1,136 @@
+# @veritrust/mcpf-client (Node.js / TypeScript SDK)
+
+A minimal Node.js / TypeScript client SDK for interacting with **MCP Trust Registry** implementations of the **MCP Trust Framework (MCPF)**.
+
+This SDK helps you:
+
+- Query MCP registry endpoints
+- Retrieve registry entries by DID
+- Search for MCP servers by metadata
+- Perform basic validation of MCPServerCredentials (time window, assurance level, optional JSON Schema validation)
+
+> ⚠️ This SDK does **not** implement full cryptographic verification of Verifiable Credentials.  
+> It focuses on structure and simple policy checks.
+
+---
+
+## Installation
+
+From within this subdirectory for local development:
+
+```bash
+cd sdks/node
+npm install
+npm run build
+
+
+If published as a package, you would install it like:
+
+npm install @veritrust/mcpf-client
+
+Quick Start
+import { RegistryClient } from "./dist"; // or "@veritrust/mcpf-client" after publishing
+import { isCredentialValidNow, checkAssuranceLevel } from "./dist/verification";
+
+const REGISTRY_URL = "http://localhost:8080";
+const SERVER_DID = "did:web:veritrust.vc:mcp:edgeguard-siem";
+
+async function main() {
+  const client = new RegistryClient(REGISTRY_URL);
+
+  // 1. Get registry entry
+  const entry = await client.getServer(SERVER_DID);
+  console.log("Registry entry:", entry);
+
+  // 2. Fetch MCPServerCredential from first credential URL
+  if (!entry.credentials.length) {
+    throw new Error("No credentials listed for this server.");
+  }
+
+  const credUrl = entry.credentials[0];
+  const credResp = await fetch(credUrl);
+  if (!credResp.ok) {
+    throw new Error(`Failed to fetch credential: ${credResp.status} ${credResp.statusText}`);
+  }
+  const credential = await credResp.json();
+
+  // 3. Basic checks
+  if (!isCredentialValidNow(credential)) {
+    throw new Error("Credential is not within its validity period.");
+  }
+
+  if (!checkAssuranceLevel(credential, "verified")) {
+    throw new Error("Credential assurance level is below required minimum.");
+  }
+
+  console.log("Credential is current and meets assurance requirements.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+
+This example assumes Node.js 18+ where fetch is available globally.
+If you’re on an older Node version, you can polyfill it (e.g., with node-fetch).
+
+API Overview
+RegistryClient
+import { RegistryClient } from "@veritrust/mcpf-client";
+
+const client = new RegistryClient("http://localhost:8080");
+
+// List servers
+const page = await client.listServers(1, 50);
+
+// Get server by DID
+const entry = await client.getServer("did:web:example.com:mcp:myserver");
+
+// Search servers
+const results = await client.searchServers({ capability: "telemetry", tag: "security" });
+
+// Upsert (register/update) a server
+await client.upsertServer(entry);
+
+Types
+
+All main data structures are defined in src/types.ts and exported from the package:
+
+Metadata
+
+RegistryEntry
+
+PaginatedServers
+
+SearchResults
+
+Issuer
+
+RevokedServer
+
+RevokedCredential
+
+RevocationStatus
+
+Verification Helpers
+
+In src/verification.ts (also exported):
+
+isCredentialValidNow(credential: any, now?: Date): boolean
+
+checkAssuranceLevel(credential: any, minimumLevel?: string): boolean
+
+validateCredentialStructure(credential: any, schema: any): void
+(uses ajv and ajv-formats for JSON Schema validation)
+
+Limitations
+
+VC crypto proof verification is out of scope for this SDK.
+
+No caching or advanced trust policy features are included.
+
+Intended as a simple building block for hosts/agents integrating with an MCP Trust Registry.
+
+
+---

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@veritrust/mcpf-client",
+  "version": "0.1.0",
+  "description": "Node.js/TypeScript client SDK for MCP Trust Framework registries",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "lint": "echo \"No lint configured\"",
+    "test": "echo \"No tests configured\""
+  },
+  "keywords": [
+    "mcp",
+    "trust",
+    "registry",
+    "verifiable-credentials",
+    "did"
+  ],
+  "author": "Veritrust",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0"
+  }
+}

--- a/sdks/node/src/client.ts
+++ b/sdks/node/src/client.ts
@@ -1,0 +1,214 @@
+import {
+  RegistryEntry,
+  PaginatedServers,
+  SearchResults,
+  RevocationStatus,
+  Issuer
+} from "./types";
+
+export interface RegistryClientOptions {
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Client for interacting with an MCP Trust Registry that implements
+ * the MCP Trust Framework (MCPF) API.
+ */
+export class RegistryClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(baseUrl: string, options: RegistryClientOptions = {}) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.fetchImpl = options.fetchImpl ?? (globalThis.fetch as typeof fetch);
+
+    if (!this.fetchImpl) {
+      throw new Error(
+        "No fetch implementation available. Use Node.js 18+ or provide fetchImpl in options."
+      );
+    }
+  }
+
+  // --- internal helpers ---
+
+  private async get(path: string, params?: Record<string, string>): Promise<any> {
+    const url = new URL(this.baseUrl + path);
+
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        url.searchParams.set(key, value);
+      }
+    }
+
+    const resp = await this.fetchImpl(url.toString());
+    if (!resp.ok) {
+      let detail: any;
+      try {
+        detail = await resp.json();
+      } catch {
+        detail = await resp.text();
+      }
+      throw new Error(
+        `Registry GET ${path} failed: ${resp.status} ${resp.statusText} – ${JSON.stringify(
+          detail
+        )}`
+      );
+    }
+
+    return resp.json();
+  }
+
+  private async post(path: string, body: any): Promise<any> {
+    const url = this.baseUrl + path;
+    const resp = await this.fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(body)
+    });
+
+    if (!resp.ok) {
+      let detail: any;
+      try {
+        detail = await resp.json();
+      } catch {
+        detail = await resp.text();
+      }
+      throw new Error(
+        `Registry POST ${path} failed: ${resp.status} ${resp.statusText} – ${JSON.stringify(
+          detail
+        )}`
+      );
+    }
+
+    return resp.json();
+  }
+
+  // --- public API ---
+
+  /**
+   * List MCP servers known to the registry.
+   */
+  async listServers(page = 1, limit = 50): Promise<PaginatedServers> {
+    const data = await this.get("/mcp/servers", {
+      page: String(page),
+      limit: String(limit)
+    });
+
+    const items = (data.items || []) as any[];
+    return {
+      page: data.page ?? page,
+      limit: data.limit ?? limit,
+      total: data.total ?? items.length,
+      items: items.map((raw) => this.toRegistryEntry(raw))
+    };
+  }
+
+  /**
+   * Get a single MCP server registry entry by DID.
+   */
+  async getServer(did: string): Promise<RegistryEntry> {
+    const data = await this.get(`/mcp/servers/${encodeURIComponent(did)}`);
+    return this.toRegistryEntry(data);
+  }
+
+  /**
+   * Search for MCP servers by simple metadata filters.
+   */
+  async searchServers(filters: {
+    capability?: string;
+    tag?: string;
+    organization?: string;
+    country?: string;
+  }): Promise<SearchResults> {
+    const params: Record<string, string> = {};
+    if (filters.capability) params.capability = filters.capability;
+    if (filters.tag) params.tag = filters.tag;
+    if (filters.organization) params.organization = filters.organization;
+    if (filters.country) params.country = filters.country;
+
+    const data = await this.get("/mcp/search", params);
+    const items = (data.items || []) as any[];
+    return {
+      items: items.map((raw) => this.toRegistryEntry(raw))
+    };
+  }
+
+  /**
+   * Register or update a registry entry.
+   *
+   * NOTE: In real deployments, this should be authenticated.
+   */
+  async upsertServer(entry: RegistryEntry): Promise<{ status: string; did: string }> {
+    const body = {
+      did: entry.did,
+      endpoint: entry.endpoint,
+      manifest: entry.manifest,
+      credentials: entry.credentials,
+      metadata: {
+        capabilities: entry.metadata.capabilities,
+        organization: entry.metadata.organization,
+        country: entry.metadata.country,
+        tags: entry.metadata.tags,
+        status: entry.metadata.status
+      }
+    };
+
+    return this.post("/mcp/servers", body);
+  }
+
+  /**
+   * List recognized issuers.
+   */
+  async listIssuers(): Promise<{ issuers: Issuer[] }> {
+    const data = await this.get("/mcp/issuers");
+    const rawIssuers = (data.issuers || []) as any[];
+    const issuers: Issuer[] = rawIssuers.map((d) => ({
+      id: d.id,
+      name: d.name,
+      documentation: d.documentation
+    }));
+    return { issuers };
+  }
+
+  /**
+   * Get revoked servers and credentials as reported by the registry.
+   */
+  async getRevocations(): Promise<RevocationStatus> {
+    const data = await this.get("/mcp/revocations");
+    const revokedServers = ((data.revokedServers || []) as any[]).map((d) => ({
+      did: d.did,
+      revokedAt: d.revokedAt,
+      reason: d.reason
+    }));
+    const revokedCredentials = ((data.revokedCredentials || []) as any[]).map((d) => ({
+      id: d.id,
+      revokedAt: d.revokedAt,
+      reason: d.reason
+    }));
+    return {
+      revokedServers,
+      revokedCredentials
+    };
+  }
+
+  // --- helpers ---
+
+  private toRegistryEntry(raw: any): RegistryEntry {
+    const metadata = raw.metadata || {};
+    return {
+      did: raw.did,
+      endpoint: raw.endpoint,
+      manifest: raw.manifest,
+      credentials: raw.credentials || [],
+      metadata: {
+        capabilities: metadata.capabilities || [],
+        organization: metadata.organization,
+        country: metadata.country,
+        tags: metadata.tags || [],
+        status: metadata.status
+      }
+    };
+  }
+}

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./client";
+export * from "./verification";

--- a/sdks/node/src/types.ts
+++ b/sdks/node/src/types.ts
@@ -1,0 +1,49 @@
+export interface Metadata {
+  capabilities: string[];
+  organization?: string;
+  country?: string;
+  tags: string[];
+  status?: string;
+}
+
+export interface RegistryEntry {
+  did: string;
+  endpoint: string;
+  manifest: string;
+  credentials: string[];
+  metadata: Metadata;
+}
+
+export interface Issuer {
+  id: string;
+  name: string;
+  documentation?: string;
+}
+
+export interface RevokedServer {
+  did: string;
+  revokedAt: string;
+  reason?: string;
+}
+
+export interface RevokedCredential {
+  id: string;
+  revokedAt: string;
+  reason?: string;
+}
+
+export interface RevocationStatus {
+  revokedServers: RevokedServer[];
+  revokedCredentials: RevokedCredential[];
+}
+
+export interface PaginatedServers {
+  page: number;
+  limit: number;
+  total: number;
+  items: RegistryEntry[];
+}
+
+export interface SearchResults {
+  items: RegistryEntry[];
+}

--- a/sdks/node/src/verification.ts
+++ b/sdks/node/src/verification.ts
@@ -1,0 +1,83 @@
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+
+/**
+ * Minimal ISO 8601 date-time parsing with basic error handling.
+ */
+export function parseIsoDateTime(value: string): Date {
+  const d = new Date(value);
+  if (isNaN(d.getTime())) {
+    throw new Error(`Invalid date-time: ${value}`);
+  }
+  return d;
+}
+
+/**
+ * Check if an MCPServerCredential is within its validity window.
+ *
+ * Expects fields:
+ *  - credential.issuedAt
+ *  - credential.validUntil
+ */
+export function isCredentialValidNow(credential: any, now: Date = new Date()): boolean {
+  const issuedAtStr = credential?.issuedAt;
+  const validUntilStr = credential?.validUntil;
+
+  if (!issuedAtStr || !validUntilStr) {
+    return false;
+  }
+
+  let issuedAt: Date;
+  let validUntil: Date;
+  try {
+    issuedAt = parseIsoDateTime(issuedAtStr);
+    validUntil = parseIsoDateTime(validUntilStr);
+  } catch {
+    return false;
+  }
+
+  return issuedAt <= now && now <= validUntil;
+}
+
+/**
+ * Check if the credential's assuranceLevel meets or exceeds the given minimum.
+ *
+ * Levels (from lowest to highest):
+ *   - basic
+ *   - verified
+ *   - certified
+ */
+export function checkAssuranceLevel(credential: any, minimumLevel: string = "basic"): boolean {
+  const levels = ["basic", "verified", "certified"];
+
+  const subject = credential?.credentialSubject || {};
+  const level: string = subject.assuranceLevel || "basic";
+
+  const minIndex = levels.indexOf(minimumLevel);
+  const levelIndex = levels.indexOf(level);
+
+  if (minIndex === -1 || levelIndex === -1) {
+    return false;
+  }
+
+  return levelIndex >= minIndex;
+}
+
+/**
+ * Validate a credential against a JSON Schema (e.g. specs/credential-schema.json).
+ *
+ * Uses Ajv and ajv-formats internally.
+ */
+export function validateCredentialStructure(credential: any, schema: any): void {
+  const ajv = new Ajv({ allErrors: true });
+  addFormats(ajv);
+
+  const validate = ajv.compile(schema);
+  const valid = validate(credential);
+  if (!valid) {
+    const errors = (validate.errors || [])
+      .map((e) => `- ${e.instancePath || "/"} ${e.message}`)
+      .join("\n");
+    throw new Error(`Credential does not conform to schema:\n${errors}`);
+  }
+}

--- a/sdks/node/tsconfig.json
+++ b/sdks/node/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add Node.js/TypeScript SDK package scaffolding for MCP trust registry client
- implement registry client, verification helpers, and type definitions
- include build configuration and README usage instructions

## Testing
- not run (not applicable for static additions)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692586114e10832b943aeea36a8d4eab)