### PR TITLE
Add governance docs

### DIFF
--- a/governance/contributors.md
+++ b/governance/contributors.md
@@ -1,0 +1,116 @@
+# MCP Trust Framework – Contributors Guide
+
+This document describes how to contribute to the **MCP Trust Framework (MCPF)** project at the governance level (spec design, roadmap, alignment), beyond regular code contributions.
+
+For code and documentation contribution details, see also the root [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+---
+
+## 1. Roles
+
+The project recognizes several informal roles:
+
+- **Maintainers**  
+  Coordinate releases, approve changes to core specifications, and manage the repository.
+
+- **Contributors**  
+  Submit issues, pull requests, and proposals for improvements to specs, SDKs, and implementations.
+
+- **Advisors / Reviewers**  
+  External experts (e.g., from industry, academia, or standards bodies) who review documents and provide feedback on security, interoperability, and governance.
+
+---
+
+## 2. Areas of Contribution
+
+You can contribute in several ways:
+
+1. **Specifications**
+   - Propose changes or extensions to:
+     - `specs/MCPF-1.0.md`
+     - `specs/registry-api.md`
+     - `specs/credential-schema.json`
+     - `specs/did-profile.md`
+     - `specs/security-considerations.md`
+   - Suggest clarifications or examples.
+   - Help align with emerging standards and best practices.
+
+2. **Reference Implementations**
+   - Improve the FastAPI registry (`registry-reference-implementation/`).
+   - Add persistence backends (e.g., PostgreSQL, SQLite).
+   - Implement authentication / authorization options.
+   - Harden security and logging.
+
+3. **SDKs**
+   - Enhance Python SDK (`sdks/python/`).
+   - Enhance Node/TypeScript SDK (`sdks/node/`).
+   - Add support for additional languages where appropriate.
+
+4. **Use Cases and Examples**
+   - Contribute example registry entries, credentials, and DID documents.
+   - Write integration recipes for popular MCP hosts/agents.
+   - Document real-world deployment patterns.
+
+5. **Governance and Processes**
+   - Help refine the roadmap.
+   - Propose working groups or topic-focused task forces.
+   - Align MCPF with regulatory or compliance frameworks where relevant.
+
+---
+
+## 3. How to Propose Changes
+
+### 3.1. Specifications & Governance
+
+1. Open an issue with a descriptive title, prefixed with:
+   - `[SPEC]` – for changes to core spec documents.
+   - `[GOV]` – for governance or process changes.
+2. Clearly describe:
+   - The problem you are solving.
+   - The proposed change.
+   - Any impact on existing implementations.
+3. Be prepared to iterate on the proposal based on feedback.
+4. Once there is broad agreement, submit a PR referencing the issue.
+
+### 3.2. Code Contributions
+
+1. Open a regular GitHub issue or PR.
+2. Keep changes focused; avoid mixing spec and code changes in the same PR unless necessary.
+3. Update relevant docs and READMEs when changing public APIs.
+
+---
+
+## 4. Decision Process
+
+At the current stage:
+
+- Maintainers review PRs and issues.
+- For breaking changes in specs:
+  - Discussion must take place in public issues.
+  - A clear migration path or rationale must be documented.
+  - The `versioning.md` rules must be followed.
+
+When a broader steering group or advisory board is formed, this document may be updated to reflect more formal governance.
+
+---
+
+## 5. Communication
+
+- Primary channel: GitHub Issues and Pull Requests.
+- Additional communication channels (WG calls, mailing lists, etc.) may be introduced later and documented here.
+
+---
+
+## 6. Code of Conduct
+
+All contributors are expected to:
+
+- Treat others with respect.
+- Keep discussions technical and constructive.
+- Help maintain a welcoming environment for newcomers.
+
+Behaviors inconsistent with these expectations may result in moderation actions by the maintainers.
+
+---
+
+Thank you for helping shape the MCP Trust Framework.

--- a/governance/roadmap.md
+++ b/governance/roadmap.md
@@ -1,0 +1,140 @@
+# MCP Trust Framework – Roadmap
+
+This roadmap provides a high-level view of where the **MCP Trust Framework (MCPF)** and related components are headed.  
+It is intentionally simple and may evolve based on community feedback and real-world deployments.
+
+---
+
+## Phase 1 – Foundation (MVP Spec + Registry)
+
+**Goal:** Establish a working end-to-end baseline.
+
+**Scope:**
+
+- Publish core specifications:
+  - `MCPF-1.0` (draft)
+  - `registry-api.md`
+  - `credential-schema.json`
+  - `did-profile.md`
+  - `security-considerations.md`
+- Provide:
+  - FastAPI-based reference registry (in-memory store)
+  - Python and Node/TS SDKs (MVP)
+- Include working examples:
+  - Sample registry entry
+  - Sample MCPServerCredential
+  - Sample DID Document
+  - Minimal verification guides (Python & Node)
+
+**Exit Criteria:**
+
+- Registry implementation running successfully against the spec.
+- At least one real MCP server integrated via DID + registry.
+- Basic documentation and examples available.
+
+---
+
+## Phase 2 – Persistence, Auth, and Policy Hooks
+
+**Goal:** Make the registry practical for early production pilots.
+
+**Potential Work Items:**
+
+- Add persistent storage options:
+  - SQLite or PostgreSQL backend for registry entries
+  - Simple migration and configuration
+- Introduce authentication / authorization:
+  - API keys or OAuth2 / OIDC for `POST /mcp/servers`
+  - Role concepts (e.g., admin, server-owner)
+- Add policy hook points:
+  - Allow registries to annotate entries with policy hints.
+  - Ensure SDKs expose fields enough for host policies.
+
+**Exit Criteria:**
+
+- A small number of pilot deployments using persistent registry.
+- Clear examples of policy integration with at least one MCP host.
+
+---
+
+## Phase 3 – Federation and Multi-Registry Support
+
+**Goal:** Enable multiple registries and trust authorities to coexist.
+
+**Potential Work Items:**
+
+- Define a minimal pattern for registry federation:
+  - Cross-referencing of registry entries
+  - Optional upstream / downstream relationships
+- Expand `.well-known` metadata format:
+  - Advertise supported versions, trust domains, and capabilities.
+- SDK enhancements:
+  - Support querying multiple registries and merging results.
+  - Handle conflicting or overlapping entries gracefully.
+
+**Exit Criteria:**
+
+- Demonstrated interoperability between at least two independent registries.
+- Documented examples of federation topologies (e.g., local + global).
+
+---
+
+## Phase 4 – Deep VC / DID Integration and Security Hardening
+
+**Goal:** Strengthen the trust layer for security-sensitive environments.
+
+**Potential Work Items:**
+
+- Enhance guidance on:
+  - VC proof suites (e.g., Ed25519, ECDSA-based)
+  - Recommended DID methods for different contexts (e.g., did:web, did:ebsi)
+- Add concrete examples of:
+  - Full cryptographic verification in SDKs (behind optional feature flags)
+  - Integration with HSM/KMS for issuers
+- Harden registry reference implementation:
+  - Improved logging and audit trails
+  - Rate limiting and basic abuse protection
+  - Better error reporting and observability
+
+**Exit Criteria:**
+
+- At least one security-focused deployment in a regulated or critical setting.
+- External review or audit of the security model for at least one implementation.
+
+---
+
+## Phase 5 – Ecosystem Integration and Standardization
+
+**Goal:** Align MCPF with broader AI, security, and identity ecosystems.
+
+**Potential Work Items:**
+
+- Integration recipes for:
+  - Specific MCP hosts / agents
+  - AI frameworks and orchestration tools
+- Mapping to:
+  - Relevant standards or regulatory frameworks (where applicable)
+  - Existing PKI / identity infrastructures (e.g., enterprise CAs, IAM systems)
+- Consider forming:
+  - A small working group or advisory board
+  - A formal draft for external standards bodies if there is demand
+
+**Exit Criteria:**
+
+- Real-world multi-vendor deployments using MCPF.
+- Recognition or alignment with at least one external community, consortium, or initiative.
+
+---
+
+## How to Influence the Roadmap
+
+- Open GitHub issues with prefix:
+  - `[ROADMAP]` for proposals or adjustments.
+- Provide:
+  - Use case descriptions
+  - Impact analysis
+  - Implementation estimates (if possible)
+- Larger shifts (e.g., new phases) will be discussed in public issues and updated here.
+
+This roadmap is deliberately high-level and does not promise specific dates.  
+It is intended as a guide for contributors and adopters of the MCP Trust Framework.

--- a/governance/versioning.md
+++ b/governance/versioning.md
@@ -1,0 +1,179 @@
+# MCP Trust Framework – Versioning Policy
+
+This document defines how versions are managed for:
+
+1. **Specifications** (MCPF, registry API, schemas)
+2. **Reference Implementations** (registry, tools)
+3. **SDKs** (Python, Node/TS)
+
+The goal is to keep changes predictable and transparent for implementers.
+
+---
+
+## 1. Semantic Versioning
+
+All components use **semantic versioning** of the form:
+
+```text
+MAJOR.MINOR.PATCH
+
+
+MAJOR – breaking changes
+
+MINOR – new features with backward compatibility
+
+PATCH – bug fixes and documentation-only changes
+
+2. Specification Versioning
+
+The main spec (MCPF-1.0.md, etc.) is versioned at the document level.
+
+File naming convention:
+
+MCPF-1.0.md
+
+MCPF-1.1.md
+
+MCPF-2.0.md
+
+Each spec documents its own version in the header.
+
+2.1. Patch-level Changes
+
+Examples:
+
+Clarifying text
+
+Fixing typos
+
+Adjusting examples without changing semantics
+
+Patch-level changes:
+
+May be applied in-place to the current spec file.
+
+Should be noted in a change log or the spec’s “Change History” section.
+
+2.2. Minor Changes (Backward Compatible)
+
+Examples:
+
+Adding optional fields
+
+Adding new non-breaking endpoints in the registry API
+
+Adding new credential types that do not invalidate existing ones
+
+Minor changes:
+
+Should update the minor version (e.g., 1.0 → 1.1).
+
+Must preserve compatibility for existing implementations that follow the previous minor version.
+
+2.3. Major Changes (Breaking)
+
+Examples:
+
+Removing or renaming required fields
+
+Changing the meaning of existing fields
+
+Removing or fundamentally altering endpoints
+
+Any change that would cause a fully conformant implementation to break or misinterpret data
+
+Major changes:
+
+Require creating a new spec version, e.g., MCPF-2.0.md.
+
+Existing implementations may need migration steps, which should be documented.
+
+3. Registry Implementation Versioning
+
+The reference registry (registry-reference-implementation/) follows semantic versioning in its release tags.
+
+Its version is independent from the spec version, but:
+
+Each release notes which spec version(s) it supports (e.g., MCPF 1.0).
+
+A registry release may implement multiple spec versions or provide compatibility modes if needed.
+
+Breaking changes (e.g., API behavior or config semantics) require a major version bump.
+
+4. SDK Versioning
+
+SDKs (sdks/python, sdks/node) each:
+
+Use semantic versioning in their respective packaging metadata
+
+Python: pyproject.toml
+
+Node: package.json
+
+Document which spec version(s) they target and support.
+
+Examples:
+
+Python: mcpf-client version 0.1.0
+
+Node: @veritrust/mcpf-client version 0.1.0
+
+4.1. Non-breaking SDK Changes
+
+Examples:
+
+Adding helper functions
+
+Adding optional parameters
+
+Improving error messages
+
+Documentation updates
+
+These should result in MINOR or PATCH version bumps.
+
+4.2. Breaking SDK Changes
+
+Examples:
+
+Renaming or removing public methods
+
+Changing method signatures incompatibly
+
+Changing return types in ways that break existing code
+
+These require a MAJOR version bump for that SDK.
+
+5. Cross-Version Compatibility
+
+The project aims to:
+
+Keep spec changes incremental and backward-compatible where feasible.
+
+Provide clear guidance when compatibility can’t be maintained.
+
+Implementers should:
+
+Pin to specific spec versions as needed.
+
+Note which MCPF version their software supports in their own documentation.
+
+Avoid mixing incompatible versions without explicit migration plans.
+
+6. Change Communication
+
+For significant changes:
+
+A changelog entry SHOULD be added (either per module or as a central changelog).
+
+Maintainers SHOULD describe:
+
+What changed
+
+Why it changed
+
+Impact on existing implementations
+
+Migration guidelines (for breaking changes)
+
+This versioning policy may itself evolve. Any substantive modifications will be discussed publicly (e.g., via GitHub issues) and updated in this file.


### PR DESCRIPTION
## Summary
- add governance-level contributors guide for the MCP Trust Framework
- document roadmap phases and contribution touchpoints
- outline semantic versioning policy for specs, registry, and SDKs

## Testing
- Not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692586b79810832bbc8facb25f0997ea)