### PR TITLE
Improve registry sample loading and SDK documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ MCPF is compatible with any existing MCP server or host. It does not change the 
    See [`examples/`](examples/) for sample registry entries, MCP server credentials, and DID documents.
 
 
+## .well-known discovery
+
+A registry operator can expose discovery metadata at:
+
+```text
+https://<domain>/.well-known/mcp-trust-registry.json
+```
+
+An example structure is:
+
+```json
+{
+  "mcpfVersion": "1.0",
+  "registry": {
+    "name": "Veritrust MCP Trust Registry",
+    "baseUrl": "https://ans.veritrust.vc/mcp"
+  },
+  "issuer": {
+    "did": "did:web:veritrust.vc",
+    "name": "Veritrust"
+  }
+}
+```
+
+Clients can fetch this file first and use `registry.baseUrl` to configure a `RegistryClient`.
+
+
 ## Status
 
 - Specification: **Draft 1.0**

--- a/registry-reference-implementation/Dockerfile
+++ b/registry-reference-implementation/Dockerfile
@@ -14,8 +14,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy source
+# Copy source and examples
 COPY src ./src
+COPY ../examples ./examples
 
 WORKDIR /app/src
 

--- a/registry-reference-implementation/README.md
+++ b/registry-reference-implementation/README.md
@@ -8,15 +8,14 @@ It provides:
 - HTTP API as specified in `specs/registry-api.md`
 - Preloaded example entry from `examples/sample-registry-entry.json`
 
-> ⚠️ This implementation is **for demonstration and testing**.  
-> It does **not** implement authentication, cryptographic verification, or persistent storage.
+> ⚠️ This implementation is **for demonstration and testing**. It does **not** implement authentication, cryptographic verification, or persistent storage.
 
 ---
 
 ## 1. Requirements
 
 - Python 3.10 or newer
-- `pip` or `uv` / `pipx`
+- `pip` (or a compatible installer such as `uv` / `pipx`)
 - Optionally Docker & docker-compose
 
 ---
@@ -35,76 +34,69 @@ source .venv/bin/activate  # on Windows: .venv\Scripts\activate
 # Install dependencies
 pip install -r requirements.txt
 
-
-Run the service:
-
+# Run the service
 cd src
 uvicorn main:app --host 0.0.0.0 --port 8080 --reload
+```
 
-
-The registry will be available at:
-
-http://localhost:8080
-
+The registry will be available at `http://localhost:8080`.
 
 Key endpoints:
 
-GET /mcp/servers
+- `GET /mcp/servers`
+- `GET /mcp/servers/{did}`
+- `GET /mcp/search`
+- `POST /mcp/servers`
+- `GET /mcp/issuers`
+- `GET /mcp/revocations`
 
-GET /mcp/servers/{did}
+---
 
-GET /mcp/search
-
-POST /mcp/servers
-
-GET /mcp/issuers
-
-GET /mcp/revocations
-
-3. Install and Run with Docker
+## 3. Install and Run with Docker
 
 From the repository root:
 
+```bash
 cd registry-reference-implementation
 docker-compose up --build
+```
 
+The registry will listen on `http://localhost:8080`.
 
-The registry will listen on:
+---
 
-http://localhost:8080
-
-4. Example Calls
+## 4. Example Calls
 
 List servers:
 
+```bash
 curl http://localhost:8080/mcp/servers
-
+```
 
 Get one server by DID:
 
+```bash
 curl "http://localhost:8080/mcp/servers/did:web:veritrust.vc:mcp:edgeguard-siem"
-
+```
 
 Search by capability:
 
+```bash
 curl "http://localhost:8080/mcp/search?capability=telemetry"
-
+```
 
 Register a new server:
 
+```bash
 curl -X POST http://localhost:8080/mcp/servers \
   -H "Content-Type: application/json" \
   -d @../examples/sample-registry-entry.json
-
-5. Notes
-
-Storage is in-memory only; restarting the service will reset the data.
-
-On startup, the registry will attempt to load:
-
-../examples/sample-registry-entry.json if present.
-
-Authentication and cryptographic verification are intentionally out-of-scope for this MVP.
-
+```
 
 ---
+
+## 5. Notes
+
+- Storage is in-memory only; restarting the service will reset the data.
+- On startup, the registry will attempt to load `../examples/sample-registry-entry.json` if present (and the same file in Docker at `/app/examples/`).
+- Authentication and cryptographic verification are intentionally out-of-scope for this MVP.

--- a/registry-reference-implementation/src/main.py
+++ b/registry-reference-implementation/src/main.py
@@ -38,23 +38,26 @@ storage = InMemoryStorage()
 
 def _load_example_entry() -> None:
     """
-    Try to load the sample registry entry from ../../examples/sample-registry-entry.json
-    and add a default issuer.
+    Try to load the sample registry entry from known locations and add a default issuer.
     """
-    try:
-        # from src/main.py → go two levels up to repo root
-        base = Path(__file__).resolve().parents[2]
-        example_path = base / "examples" / "sample-registry-entry.json"
-        if example_path.is_file():
-            with example_path.open("r", encoding="utf-8") as f:
-                data = json.load(f)
-            entry = RegistryEntry(**data)
-            storage.upsert_server(entry)
-            print(f"[startup] Loaded example registry entry from {example_path}")
-        else:
-            print(f"[startup] No example registry entry found at {example_path}")
-    except Exception as exc:
-        print(f"[startup] Failed to load example registry entry: {exc!r}")
+    base = Path(__file__).resolve()
+    candidates = [
+        # Repository layout: repo_root/examples/sample-registry-entry.json
+        base.parents[2] / "examples" / "sample-registry-entry.json",
+        # Docker layout: /app/examples/sample-registry-entry.json (src/ is copied separately)
+        base.parents[1] / "examples" / "sample-registry-entry.json",
+    ]
+
+    example_path = next((path for path in candidates if path.is_file()), None)
+
+    if example_path is None:
+        print("[startup] No example registry entry found in any known location")
+    else:
+        with example_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        entry = RegistryEntry(**data)
+        storage.upsert_server(entry)
+        print(f"[startup] Loaded example registry entry from {example_path}")
 
     # Add a default issuer for demonstration purposes
     storage.add_issuer(

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -1,6 +1,6 @@
 # @veritrust/mcpf-client (Node.js / TypeScript SDK)
 
-A minimal Node.js / TypeScript client SDK for interacting with **MCP Trust Registry** implementations of the **MCP Trust Framework (MCPF)**.
+A minimal Node.js / TypeScript client SDK for interacting with MCP Trust Registry implementations of the **MCP Trust Framework (MCPF)**.
 
 This SDK helps you:
 
@@ -9,28 +9,14 @@ This SDK helps you:
 - Search for MCP servers by metadata
 - Perform basic validation of MCPServerCredentials (time window, assurance level, optional JSON Schema validation)
 
-> ⚠️ This SDK does **not** implement full cryptographic verification of Verifiable Credentials.  
-> It focuses on structure and simple policy checks.
+> ⚠️ This SDK does **not** implement full cryptographic verification of Verifiable Credentials. It focuses on structure and simple policy checks.
 
 ---
 
-## Installation
+## Quick Start
 
-From within this subdirectory for local development:
-
-```bash
-cd sdks/node
-npm install
-npm run build
-
-
-If published as a package, you would install it like:
-
-npm install @veritrust/mcpf-client
-
-Quick Start
-import { RegistryClient } from "./dist"; // or "@veritrust/mcpf-client" after publishing
-import { isCredentialValidNow, checkAssuranceLevel } from "./dist/verification";
+```ts
+import { RegistryClient, isCredentialValidNow, checkAssuranceLevel } from "@veritrust/mcpf-client";
 
 const REGISTRY_URL = "http://localhost:8080";
 const SERVER_DID = "did:web:veritrust.vc:mcp:edgeguard-siem";
@@ -42,7 +28,7 @@ async function main() {
   const entry = await client.getServer(SERVER_DID);
   console.log("Registry entry:", entry);
 
-  // 2. Fetch MCPServerCredential from first credential URL
+  // 2. Fetch MCPServerCredential from the first credential URL
   if (!entry.credentials.length) {
     throw new Error("No credentials listed for this server.");
   }
@@ -70,13 +56,31 @@ main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
+```
 
+This example assumes **Node.js 18+**, where `fetch` is available globally. On older Node versions, add a polyfill such as [`node-fetch`](https://www.npmjs.com/package/node-fetch).
 
-This example assumes Node.js 18+ where fetch is available globally.
-If you’re on an older Node version, you can polyfill it (e.g., with node-fetch).
+## Installation
 
-API Overview
-RegistryClient
+If published as a package:
+
+```bash
+npm install @veritrust/mcpf-client
+```
+
+## Build from source
+
+```bash
+cd sdks/node
+npm install
+npm run build
+```
+
+## API Overview
+
+### RegistryClient
+
+```ts
 import { RegistryClient } from "@veritrust/mcpf-client";
 
 const client = new RegistryClient("http://localhost:8080");
@@ -92,45 +96,31 @@ const results = await client.searchServers({ capability: "telemetry", tag: "secu
 
 // Upsert (register/update) a server
 await client.upsertServer(entry);
+```
 
-Types
+### Types
 
-All main data structures are defined in src/types.ts and exported from the package:
+All main data structures are defined in `src/types.ts` and exported from the package:
 
-Metadata
+- `Metadata`
+- `RegistryEntry`
+- `PaginatedServers`
+- `SearchResults`
+- `Issuer`
+- `RevokedServer`
+- `RevokedCredential`
+- `RevocationStatus`
 
-RegistryEntry
+### Verification Helpers
 
-PaginatedServers
+In `src/verification.ts` (also exported):
 
-SearchResults
+- `isCredentialValidNow(credential: any, now?: Date): boolean`
+- `checkAssuranceLevel(credential: any, minimumLevel?: string): boolean`
+- `validateCredentialStructure(credential: any, schema: any): void` (uses `ajv` and `ajv-formats`)
 
-Issuer
+## Limitations
 
-RevokedServer
-
-RevokedCredential
-
-RevocationStatus
-
-Verification Helpers
-
-In src/verification.ts (also exported):
-
-isCredentialValidNow(credential: any, now?: Date): boolean
-
-checkAssuranceLevel(credential: any, minimumLevel?: string): boolean
-
-validateCredentialStructure(credential: any, schema: any): void
-(uses ajv and ajv-formats for JSON Schema validation)
-
-Limitations
-
-VC crypto proof verification is out of scope for this SDK.
-
-No caching or advanced trust policy features are included.
-
-Intended as a simple building block for hosts/agents integrating with an MCP Trust Registry.
-
-
----
+- VC crypto proof verification is out of scope for this SDK.
+- No caching or advanced trust policy features are included.
+- Intended as a simple building block for hosts/agents integrating with an MCP Trust Registry.

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -4,6 +4,12 @@
   "description": "Node.js/TypeScript client SDK for MCP Trust Framework registries",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rm -rf dist",

--- a/sdks/node/tsconfig.json
+++ b/sdks/node/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "declaration": true,
     "outDir": "dist",

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -16,14 +16,20 @@ This SDK helps you:
 
 ## Installation
 
-For local development (inside this monorepo), you can install in editable mode:
+For local development in this repository:
 
 ```bash
 cd sdks/python
 pip install -e .
 ```
 
-This will install the package as `mcpf_client`.
+This installs the package as `mcpf_client` from the local sources.
+
+Once published to PyPI:
+
+```bash
+pip install mcpf-client
+```
 
 ## Quick Start
 
@@ -42,8 +48,6 @@ entry = client.get_server(SERVER_DID)
 print("Registry entry:", entry)
 
 # 2. Fetch MCPServerCredential (first URL in entry.credentials)
-if not entry.credentials:
-    raise RuntimeError("No credentials listed for this server.")
 cred_url = entry.credentials[0]
 credential = requests.get(cred_url, timeout=5).json()
 


### PR DESCRIPTION
## Summary
- include the examples directory in the registry Docker image and load the sample entry from repo or container layouts
- switch the Node SDK build to CommonJS, add exports metadata, and expand Quick Start guidance
- clarify installation and usage instructions across the registry, Python SDK, and root README files

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69258ba77548832b87448375e80ad7c9)